### PR TITLE
Implemented completion for dictionary variable names

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/variable_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/variable_completions.py
@@ -209,7 +209,13 @@ def _collect_completions_from_ast(
         name = token.value
         if name.endswith("="):
             name = name[:-1].rstrip()
-
+        if name.startswith("&"):
+            dict_var = name.replace("&", "$")
+            if collector.accepts(dict_var):
+                variable_found = _VariableFoundFromToken(
+                    completion_context, token, variable_node.value, variable_name=dict_var
+                )
+                collector.on_variable(variable_found)
         if collector.accepts(name):
             variable_found = _VariableFoundFromToken(
                 completion_context, token, variable_node.value, variable_name=name

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions.py
@@ -383,8 +383,8 @@ def test_dictionary_variables_completions_with_dollar(
     from robotframework_ls.impl.completion_context import CompletionContext
     from robotframework_ls.impl import variable_completions
 
-    workspace.set_root("case10", libspec_manager=libspec_manager)
-    doc = workspace.get_doc("case10.robot")
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
     doc.source = """*** Variables ***
 &{ROBOT}   Name=Robot Framework   Version=4.0
 
@@ -404,8 +404,8 @@ def test_dictionary_variables_completions_with_ampersand(
     from robotframework_ls.impl.completion_context import CompletionContext
     from robotframework_ls.impl import variable_completions
 
-    workspace.set_root("case10", libspec_manager=libspec_manager)
-    doc = workspace.get_doc("case10.robot")
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
     doc.source = """*** Variables ***
 &{ROBOT}   Name=Robot Framework   Version=4.0
 

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions.py
@@ -375,3 +375,45 @@ Test
         CompletionContext(doc, workspace=workspace.ws)
     )
     data_regression.check(completions)
+
+
+def test_dictionary_variables_completions_with_dollar(
+    workspace, libspec_manager, data_regression
+):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl import variable_completions
+
+    workspace.set_root("case10", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case10.robot")
+    doc.source = """*** Variables ***
+&{ROBOT}   Name=Robot Framework   Version=4.0
+
+***Test Cases***
+Test dictionary variable completion
+   Log to Console   ${ROB"""
+
+    completions = variable_completions.complete(
+        CompletionContext(doc, workspace=workspace.ws)
+    )
+    data_regression.check(completions)
+
+
+def test_dictionary_variables_completions_with_ampersand(
+    workspace, libspec_manager, data_regression
+):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl import variable_completions
+
+    workspace.set_root("case10", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case10.robot")
+    doc.source = """*** Variables ***
+&{ROBOT}   Name=Robot Framework   Version=4.0
+
+***Test Cases***
+Test dictionary variable completion
+   Log to Console   &{ROB"""
+
+    completions = variable_completions.complete(
+        CompletionContext(doc, workspace=workspace.ws)
+    )
+    data_regression.check(completions)

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions/test_dictionary_variables_completions_with_ampersand.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions/test_dictionary_variables_completions_with_ampersand.yml
@@ -1,0 +1,17 @@
+- deprecated: false
+  documentation: ('Name=Robot Framework', 'Version=4.0')
+  documentationFormat: plaintext
+  insertText: '&{ROBOT}'
+  insertTextFormat: 2
+  kind: 6
+  label: '&{ROBOT}'
+  preselect: false
+  textEdit:
+    newText: '&{ROBOT}'
+    range:
+      end:
+        character: 25
+        line: 5
+      start:
+        character: 20
+        line: 5

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions/test_dictionary_variables_completions_with_dollar.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variables_completions/test_dictionary_variables_completions_with_dollar.yml
@@ -1,0 +1,17 @@
+- deprecated: false
+  documentation: ('Name=Robot Framework', 'Version=4.0')
+  documentationFormat: plaintext
+  insertText: ${ROBOT}
+  insertTextFormat: 2
+  kind: 6
+  label: ${ROBOT}
+  preselect: false
+  textEdit:
+    newText: \${ROBOT}
+    range:
+      end:
+        character: 25
+        line: 5
+      start:
+        character: 20
+        line: 5


### PR DESCRIPTION
Dictionary variable names can now be completed using the syntax:

```
${dict_var}
```

Currently they are only completed using the new syntax introduced in RF 4. which has a different meaning:

```
&{dict_var}