### PR TITLE
Implemented completion for dictionary items

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/completion_context.py
+++ b/robotframework-ls/src/robotframework_ls/impl/completion_context.py
@@ -285,6 +285,12 @@ class CompletionContext(object):
         return ast_utils.find_token(section, self.sel.line, self.sel.col)
 
     @instance_cache
+    def get_all_variables(self):
+        from robotframework_ls.impl import ast_utils
+        ast = self.get_ast()
+        return tuple(ast_utils.iter_variables(ast))
+
+    @instance_cache
     def get_current_variable(self, section=None) -> Optional[TokenInfo]:
         from robotframework_ls.impl import ast_utils
 

--- a/robotframework-ls/src/robotframework_ls/impl/dictionary_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/dictionary_completions.py
@@ -1,0 +1,102 @@
+import re
+from robot.api import Token
+from robocorp_ls_core.robotframework_log import get_logger
+from robotframework_ls.impl import ast_utils
+from robocorp_ls_core.lsp import (CompletionItem,
+                                  MarkupKind,
+                                  CompletionItemKind,
+                                  InsertTextFormat,
+                                  Position,
+                                  Range,
+                                  TextEdit)
+
+log = get_logger(__name__)
+
+
+def get_variables(completion_context):
+    variables = []
+    ast = completion_context.get_ast()
+    for node_info in ast_utils.iter_variables(ast):
+        node = node_info.node
+        var_name = node.get_token(Token.VARIABLE).value
+        var_value = node.value
+        variables.append((var_name, var_value))
+    return variables
+
+
+def get_dict_name(dict_item_access):
+    dict_variable_regex = re.compile(r"[$|&]{(\w+)}")
+    dict_name = dict_variable_regex.findall(dict_item_access)
+    return "&{" + dict_name.pop() + "}"
+
+
+def get_dict_keys(dict_item_access):
+    dict_key_regex = re.compile(r"\[([\w\s]*)\]")
+    dict_keys = dict_key_regex.findall(dict_item_access)
+    dict_keys.reverse()
+    return dict_keys
+
+
+def get_dictionary(variables, dict_name, dict_keys):
+    """
+    Get the dictionary whose keys are the autocompletion options
+    ${dict_name}([dict_key])*[<dictionary.keys()>]
+    """
+    for var_name, var_value in variables:
+        if var_name.startswith(dict_name):
+            dictionary = as_dictionary(var_value)
+            dict_entry = dict_keys.pop()
+            if dict_entry == '':
+                return dictionary
+            else:
+                dict_variable = dictionary[dict_entry]
+                dict_name = get_dict_name(dict_variable)
+                dict_keys += get_dict_keys(dict_variable)
+                return get_dictionary(variables, dict_name, dict_keys)
+    return None
+
+
+def as_dictionary(dict_tokens):
+    """
+    Parse ["key1=val1", "key2=val2",...] as a dictionary
+    """
+    return dict([token.split("=") for token in dict_tokens])
+
+
+def completion_items(dictionary, editor_range):
+    return [CompletionItem(
+             key,
+             kind=CompletionItemKind.Variable,
+             text_edit=TextEdit(editor_range, f"{key}]"),
+             insertText=key,
+             documentation=value,
+             insertTextFormat=InsertTextFormat.Snippet,
+             documentationFormat=MarkupKind.PlainText,
+             ).to_dict() for key, value in dictionary.items()]
+
+
+def complete(completion_context):
+    """
+    :param CompletionContext completion_context:
+    """
+    token_info = completion_context.get_current_variable()
+    if token_info is None:
+        return []
+    token = token_info.token
+    if not token.value.endswith("[]"):
+        return []
+    variables = get_variables(completion_context)
+    for resource_doc in completion_context.get_resource_imports_as_docs():
+        new_ctx = completion_context.create_copy(resource_doc)
+        variables += get_variables(new_ctx)
+    dict_name = get_dict_name(token.value)
+    dict_keys = get_dict_keys(token.value)
+    dictionary = get_dictionary(variables, dict_name, dict_keys)
+    if dictionary is None:
+        return []
+    selection = completion_context.sel
+    editor_range = Range(
+        start=Position(selection.line, token.col_offset + len(token.value) - len("]")),
+        end=Position(selection.line, token.end_col_offset),
+    )
+    return completion_items(dictionary, editor_range)

--- a/robotframework-ls/src/robotframework_ls/impl/dictionary_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/dictionary_completions.py
@@ -1,7 +1,8 @@
 import re
+from typing import Dict, List, Tuple
 from robot.api import Token
 from robocorp_ls_core.robotframework_log import get_logger
-from robotframework_ls.impl import ast_utils
+from robotframework_ls.impl.protocols import ICompletionContext
 from robocorp_ls_core.lsp import (CompletionItem,
                                   MarkupKind,
                                   CompletionItemKind,
@@ -11,59 +12,65 @@ from robocorp_ls_core.lsp import (CompletionItem,
                                   TextEdit)
 
 log = get_logger(__name__)
+_DICT_VARIABLE_REGEX = re.compile(r"[$|&]{(\w+)}")
+_DICT_KEY_REGEX = re.compile(r"\[([\w\s]*)\]")
 
 
-def get_variables(completion_context):
+def _get_variables(completion_context: ICompletionContext):
     variables = []
-    ast = completion_context.get_ast()
-    for node_info in ast_utils.iter_variables(ast):
+    for node_info in completion_context.get_all_variables():
         node = node_info.node
-        var_name = node.get_token(Token.VARIABLE).value
+        token = node.get_token(Token.VARIABLE)
+        if token is None:
+            continue
+        var_name = token.value
         var_value = node.value
         variables.append((var_name, var_value))
     return variables
 
 
-def get_dict_name(dict_item_access):
-    dict_variable_regex = re.compile(r"[$|&]{(\w+)}")
-    dict_name = dict_variable_regex.findall(dict_item_access)
+def _get_dict_name(dict_item_access: str):
+    dict_name = _DICT_VARIABLE_REGEX.findall(dict_item_access)
     return "&{" + dict_name.pop() + "}"
 
 
-def get_dict_keys(dict_item_access):
-    dict_key_regex = re.compile(r"\[([\w\s]*)\]")
-    dict_keys = dict_key_regex.findall(dict_item_access)
+def _get_dict_keys(dict_item_access: str):
+    dict_keys = _DICT_KEY_REGEX.findall(dict_item_access)
     dict_keys.reverse()
     return dict_keys
 
 
-def get_dictionary(variables, dict_name, dict_keys):
+def _get_dictionary(variables: List[Tuple[str, List[str]]], dict_name: str, dict_keys: List[str]):
     """
     Get the dictionary whose keys are the autocompletion options
     ${dict_name}([dict_key])*[<dictionary.keys()>]
     """
     for var_name, var_value in variables:
         if var_name.startswith(dict_name):
-            dictionary = as_dictionary(var_value)
+            dictionary = _as_dictionary(var_value)
             dict_entry = dict_keys.pop()
             if dict_entry == '':
                 return dictionary
             else:
                 dict_variable = dictionary[dict_entry]
-                dict_name = get_dict_name(dict_variable)
-                dict_keys += get_dict_keys(dict_variable)
-                return get_dictionary(variables, dict_name, dict_keys)
+                dict_name = _get_dict_name(dict_variable)
+                dict_keys += _get_dict_keys(dict_variable)
+                return _get_dictionary(variables, dict_name, dict_keys)
     return None
 
 
-def as_dictionary(dict_tokens):
+def _as_dictionary(dict_tokens: List[str]):
     """
     Parse ["key1=val1", "key2=val2",...] as a dictionary
     """
-    return dict([token.split("=") for token in dict_tokens])
+    dictionary = {}
+    for token in dict_tokens:
+        key, val = token.split("=")
+        dictionary.update({key: val})
+    return dictionary
 
 
-def completion_items(dictionary, editor_range):
+def _completion_items(dictionary: Dict[str, str], editor_range: Range):
     return [CompletionItem(
              key,
              kind=CompletionItemKind.Variable,
@@ -75,23 +82,20 @@ def completion_items(dictionary, editor_range):
              ).to_dict() for key, value in dictionary.items()]
 
 
-def complete(completion_context):
-    """
-    :param CompletionContext completion_context:
-    """
+def complete(completion_context: ICompletionContext):
     token_info = completion_context.get_current_variable()
     if token_info is None:
         return []
     token = token_info.token
     if not token.value.endswith("[]"):
         return []
-    variables = get_variables(completion_context)
+    variables = _get_variables(completion_context)
     for resource_doc in completion_context.get_resource_imports_as_docs():
         new_ctx = completion_context.create_copy(resource_doc)
-        variables += get_variables(new_ctx)
-    dict_name = get_dict_name(token.value)
-    dict_keys = get_dict_keys(token.value)
-    dictionary = get_dictionary(variables, dict_name, dict_keys)
+        variables += _get_variables(new_ctx)
+    dict_name = _get_dict_name(token.value)
+    dict_keys = _get_dict_keys(token.value)
+    dictionary = _get_dictionary(variables, dict_name, dict_keys)
     if dictionary is None:
         return []
     selection = completion_context.sel
@@ -99,4 +103,4 @@ def complete(completion_context):
         start=Position(selection.line, token.col_offset + len(token.value) - len("]")),
         end=Position(selection.line, token.end_col_offset),
     )
-    return completion_items(dictionary, editor_range)
+    return _completion_items(dictionary, editor_range)

--- a/robotframework-ls/src/robotframework_ls/impl/protocols.py
+++ b/robotframework-ls/src/robotframework_ls/impl/protocols.py
@@ -324,6 +324,9 @@ class ICompletionContext(Protocol):
     def get_current_token(self) -> Optional[TokenInfo]:
         pass
 
+    def get_all_variables(self) -> Tuple[NodeInfo, ...]:
+        pass
+
     def get_current_variable(self, section=None) -> Optional[TokenInfo]:
         pass
 

--- a/robotframework-ls/src/robotframework_ls/server_api/server.py
+++ b/robotframework-ls/src/robotframework_ls/server_api/server.py
@@ -211,6 +211,7 @@ class RobotFrameworkServerApi(PythonLanguageServer):
         from robotframework_ls.impl import section_name_completions
         from robotframework_ls.impl import keyword_completions
         from robotframework_ls.impl import variable_completions
+        from robotframework_ls.impl import dictionary_completions
         from robotframework_ls.impl import filesystem_section_completions
         from robotframework_ls.impl import keyword_parameter_completions
         from robotframework_ls.impl import auto_import_completions
@@ -243,6 +244,9 @@ class RobotFrameworkServerApi(PythonLanguageServer):
 
         if not ret:
             ret.extend(variable_completions.complete(completion_context))
+
+        if not ret:
+            ret.extend(dictionary_completions.complete(completion_context))
 
         if not ret:
             ret.extend(keyword_parameter_completions.complete(completion_context))

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions.py
@@ -26,8 +26,8 @@ def test_dictionary_entries_completions_2(
     from robotframework_ls.impl.completion_context import CompletionContext
     from robotframework_ls.impl import dictionary_completions
 
-    workspace.set_root("case2", libspec_manager=libspec_manager)
-    doc = workspace.get_doc("case2.robot")
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
     doc.source = """
 *** Variables ***
 &{Person}         Address=&{home_address}
@@ -49,8 +49,8 @@ def test_dictionary_entries_completions_3(
     from robotframework_ls.impl.completion_context import CompletionContext
     from robotframework_ls.impl import dictionary_completions
 
-    workspace.set_root("case3", libspec_manager=libspec_manager)
-    doc = workspace.get_doc("case3.robot")
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
     doc.source = """
 *** Variables ***
 &{Person}         Address=&{home_address}

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions.py
@@ -1,0 +1,68 @@
+def test_dictionary_entries_completions_1(
+    workspace, libspec_manager, data_regression
+):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl import dictionary_completions
+
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
+    doc.source = """
+*** Variables ***
+&{Person}   First name=John   Last name=Smith
+
+*** Test Cases ***
+Dictionary Variable
+    Log to Console    ${Person}[First]"""
+    line, col = doc.get_last_line_col()
+    completions = dictionary_completions.complete(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col - len("]"))
+    )
+    data_regression.check(completions)
+
+
+def test_dictionary_entries_completions_2(
+    workspace, libspec_manager, data_regression
+):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl import dictionary_completions
+
+    workspace.set_root("case2", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case2.robot")
+    doc.source = """
+*** Variables ***
+&{Person}         Address=&{home_address}
+&{home_address}   City=Somewhere   Zip Code=12345
+
+*** Test Cases ***
+Dictionary Variable
+    Log to Console    ${Person}[Address][Zip]"""
+    line, col = doc.get_last_line_col()
+    completions = dictionary_completions.complete(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col - len("]"))
+    )
+    data_regression.check(completions)
+
+
+def test_dictionary_entries_completions_3(
+    workspace, libspec_manager, data_regression
+):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl import dictionary_completions
+
+    workspace.set_root("case3", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case3.robot")
+    doc.source = """
+*** Variables ***
+&{Person}         Address=&{home_address}
+&{home_address}   City=&{Finnland}[Cities]   Zip Code=12345
+&{Finnland}       Cities=&{kaupungeista}
+&{kaupungeista}   Home of Aalto University=Espoo
+
+*** Test Cases ***
+Dictionary Variable
+    Log to Console    ${Person}[Address][City][Home of]"""
+    line, col = doc.get_last_line_col()
+    completions = dictionary_completions.complete(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col - len("]"))
+    )
+    data_regression.check(completions)

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_1.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_1.yml
@@ -1,0 +1,17 @@
+- deprecated: false
+  documentation: John
+  documentationFormat: plaintext
+  insertText: First name
+  insertTextFormat: 2
+  kind: 6
+  label: First name
+  preselect: false
+  textEdit:
+    newText: First name]
+    range:
+      end:
+        character: 38
+        line: 6
+      start:
+        character: 32
+        line: 6

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_2.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_2.yml
@@ -1,0 +1,17 @@
+- deprecated: false
+  documentation: '12345'
+  documentationFormat: plaintext
+  insertText: Zip Code
+  insertTextFormat: 2
+  kind: 6
+  label: Zip Code
+  preselect: false
+  textEdit:
+    newText: Zip Code]
+    range:
+      end:
+        character: 45
+        line: 7
+      start:
+        character: 41
+        line: 7

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_3.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_3.yml
@@ -1,0 +1,17 @@
+- deprecated: false
+  documentation: Espoo
+  documentationFormat: plaintext
+  insertText: Home of Aalto University
+  insertTextFormat: 2
+  kind: 6
+  label: Home of Aalto University
+  preselect: false
+  textEdit:
+    newText: Home of Aalto University]
+    range:
+      end:
+        character: 55
+        line: 9
+      start:
+        character: 47
+        line: 9


### PR DESCRIPTION
Dictionary items can now be completed using the syntax

```
${dict}[some index][another index]
```

That is, dictionary items, which are themselves dictionaries are also handled.

The code is meant to be short and simple. Feel free to adapt it as you see fit.