### PR TITLE
find_definition now works for dictionary variables

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/find_definition.py
+++ b/robotframework-ls/src/robotframework_ls/impl/find_definition.py
@@ -1,3 +1,4 @@
+import re
 from robotframework_ls.impl.protocols import (
     ICompletionContext,
     IDefinition,
@@ -7,6 +8,7 @@ from robotframework_ls.impl.protocols import (
 from robocorp_ls_core.protocols import check_implements
 from typing import Optional, Sequence
 
+_RF_VARIABLE = re.compile(r"([$|&|@]{\w+})")
 
 class _DefinitionFromKeyword(object):
     def __init__(self, keyword_found):
@@ -266,9 +268,9 @@ def find_definition(completion_context: ICompletionContext) -> Sequence[IDefinit
 
         token = token_info.token
         value = token.value
-
+        match = _RF_VARIABLE.findall(value)[0]
         collector = _FindDefinitionVariablesCollector(
-            completion_context.sel, token, RobotStringMatcher(value)
+            completion_context.sel, token, RobotStringMatcher(match)
         )
         collect_variables(completion_context, collector)
         return collector.matches

--- a/robotframework-ls/src/robotframework_ls/impl/find_definition.py
+++ b/robotframework-ls/src/robotframework_ls/impl/find_definition.py
@@ -8,7 +8,7 @@ from robotframework_ls.impl.protocols import (
 from robocorp_ls_core.protocols import check_implements
 from typing import Optional, Sequence
 
-_RF_VARIABLE = re.compile(r"([$|&|@]{\w+})")
+_RF_VARIABLE = re.compile(r"([$|&|@]{[\w\s]+})")
 
 class _DefinitionFromKeyword(object):
     def __init__(self, keyword_found):
@@ -268,7 +268,7 @@ def find_definition(completion_context: ICompletionContext) -> Sequence[IDefinit
 
         token = token_info.token
         value = token.value
-        match = _RF_VARIABLE.findall(value)[0]
+        match = next(iter(_RF_VARIABLE.findall(value)), value)
         collector = _FindDefinitionVariablesCollector(
             completion_context.sel, token, RobotStringMatcher(match)
         )

--- a/robotframework-ls/tests/robotframework_ls_tests/test_find_definition.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_find_definition.py
@@ -470,6 +470,26 @@ Log Global Constants
     )
 
 
+def test_find_definition_variables_dict_access(workspace, libspec_manager, data_regression):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl.find_definition import find_definition
+
+    workspace.set_root("case4", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case4.robot")
+    doc.source = """
+*** Variables ***
+&{Person}   First name=John   Last name=Smith
+
+*** Test Cases ***
+Dictionary Variable
+    Log to Console    ${Person}[First]"""
+
+    completion_context = CompletionContext(doc, workspace=workspace.ws)
+    data_regression.check(
+        _definitions_to_data_regression(find_definition(completion_context))
+    )
+
+
 def test_variables_completions_recursive(workspace, libspec_manager, data_regression):
     from robotframework_ls.impl.completion_context import CompletionContext
     from robotframework_ls.impl.find_definition import find_definition

--- a/robotframework-ls/tests/robotframework_ls_tests/test_find_definition/test_find_definition_variables_dict_access.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_find_definition/test_find_definition_variables_dict_access.yml
@@ -1,0 +1,5 @@
+- col_offset: 0
+  end_col_offset: 9
+  end_lineno: 2
+  lineno: 2
+  source: case4.robot


### PR DESCRIPTION
The current token might be `${dict}[key]`, which is not a variable. The token has to be filtered using a regex in order for `find_definition` to work for dictionary variables.