### PR TITLE
Complete dictionary items when the variable name includes spaces

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/dictionary_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/dictionary_completions.py
@@ -12,7 +12,7 @@ from robocorp_ls_core.lsp import (CompletionItem,
                                   TextEdit)
 
 log = get_logger(__name__)
-_DICT_VARIABLE_REGEX = re.compile(r"[$|&]{(\w+)}")
+_DICT_VARIABLE_REGEX = re.compile(r"[$|&]{([\w\s]+)}")
 _DICT_KEY_REGEX = re.compile(r"\[([\w\s]*)\]")
 
 

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions.py
@@ -66,3 +66,28 @@ Dictionary Variable
         CompletionContext(doc, workspace=workspace.ws, line=line, col=col - len("]"))
     )
     data_regression.check(completions)
+
+
+def test_dictionary_entries_completions_4(
+    workspace, libspec_manager, data_regression
+):
+    from robotframework_ls.impl.completion_context import CompletionContext
+    from robotframework_ls.impl import dictionary_completions
+
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
+    doc.source = """
+*** Variables ***
+&{Some Person}         Address=&{home_address}
+&{home_address}   City=&{Finnland}[Cities]   Zip Code=12345
+&{Finnland}       Cities=&{kaupungeista}
+&{kaupungeista}   Home of Aalto University=Espoo
+
+*** Test Cases ***
+Dictionary Variable
+    Log to Console    ${Some Person}[Address][City][Home of]"""
+    line, col = doc.get_last_line_col()
+    completions = dictionary_completions.complete(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col - len("]"))
+    )
+    data_regression.check(completions)

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_4.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_dictionary_entries_completions/test_dictionary_entries_completions_4.yml
@@ -1,0 +1,17 @@
+- deprecated: false
+  documentation: Espoo
+  documentationFormat: plaintext
+  insertText: Home of Aalto University
+  insertTextFormat: 2
+  kind: 6
+  label: Home of Aalto University
+  preselect: false
+  textEdit:
+    newText: Home of Aalto University]
+    range:
+      end:
+        character: 60
+        line: 9
+      start:
+        character: 52
+        line: 9


### PR DESCRIPTION
* Fixed the regex to match dictionary variables with spaces in their name.
* Added a corresponding test.