### PR TITLE
Report undefined variables as errors

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/protocols.py
+++ b/robotframework-ls/src/robotframework_ls/impl/protocols.py
@@ -47,7 +47,7 @@ class NodeInfo(Generic[Y]):
 
 TokenInfo = namedtuple("TokenInfo", "stack, node, token")
 KeywordUsageInfo = namedtuple("KeywordUsageInfo", "stack, node, token, name")
-
+VariableUsageInfo = namedtuple("VariableUsageInfo", "stack, node, token, name")
 
 class IKeywordArg(Protocol):
     @property

--- a/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis.py
@@ -232,3 +232,23 @@ def test_code_analysis_lib_with_params(
     doc = workspace.get_doc("case_params_on_lib.robot")
 
     _collect_errors(workspace, doc, data_regression, basename="no_error", config=config)
+
+def test_undefined_variable_in_dictionary(workspace, libspec_manager, data_regression):
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
+    doc.source = """*** Variables ***
+&{SOME DICT}    cwd=${CURRDIR}
+"""
+
+    _collect_errors(workspace, doc, data_regression)
+
+
+def test_undefined_variable_in_keyword_argument(workspace, libspec_manager, data_regression):
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
+    doc.source = """*** Tasks ***
+Undefined variable in keyword argument
+    Log   ${undefined}
+"""
+
+    _collect_errors(workspace, doc, data_regression)

--- a/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis/test_undefined_variable_in_dictionary.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis/test_undefined_variable_in_dictionary.yml
@@ -1,0 +1,10 @@
+- message: 'Undefined variable: ${CURRDIR}.'
+  range:
+    end:
+      character: 30
+      line: 1
+    start:
+      character: 16
+      line: 1
+  severity: 1
+  source: robotframework

--- a/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis/test_undefined_variable_in_keyword_argument.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis/test_undefined_variable_in_keyword_argument.yml
@@ -1,0 +1,10 @@
+- message: 'Undefined variable: ${undefined}.'
+  range:
+    end:
+      character: 22
+      line: 2
+    start:
+      character: 10
+      line: 2
+  severity: 1
+  source: robotframework


### PR DESCRIPTION
Variables that are not:

* defined in the Variables section of the current file or in a Resource file or in a Variables file
* defined as keyword arguments
* defined by assigning them to the return value of a keyword

are now reported as errors. Only variables passed as keyword arguments or used as dictionary values are analyzed. 