### PR TITLE
Report non-existent resource files as errors

### DIFF
--- a/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis.py
@@ -232,3 +232,15 @@ def test_code_analysis_lib_with_params(
     doc = workspace.get_doc("case_params_on_lib.robot")
 
     _collect_errors(workspace, doc, data_regression, basename="no_error", config=config)
+
+
+def test_resource_file_not_found(workspace, libspec_manager, data_regression):
+
+    workspace.set_root("case1", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case1.robot")
+    doc.source = """
+*** Settings ***
+Resource   case2.robot
+"""
+
+    _collect_errors(workspace, doc, data_regression)

--- a/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis/test_resource_file_not_found.yml
+++ b/robotframework-ls/tests/robotframework_ls_tests/test_code_analysis/test_resource_file_not_found.yml
@@ -1,0 +1,10 @@
+- message: 'Unknown resource file: case2.robot.'
+  range:
+    end:
+      character: 23
+      line: 2
+    start:
+      character: 0
+      line: 2
+  severity: 1
+  source: robotframework


### PR DESCRIPTION
If a resource file cannot be found it is reported as an error.