### PR TITLE
Matti/dynamic robot templates

### DIFF
--- a/robocorp-code/src/robocorp_code/protocols.py
+++ b/robocorp-code/src/robocorp_code/protocols.py
@@ -134,6 +134,11 @@ class ListWorkspacesActionResultDict(TypedDict):
     result: Optional[List[WorkspaceInfoDict]]
 
 
+class RobotTemplate(TypedDict):
+    name: str
+    description: str
+
+
 class CloudLoginParamsDict(TypedDict):
     credentials: str
 

--- a/robocorp-code/src/robocorp_code/rcc.py
+++ b/robocorp-code/src/robocorp_code/rcc.py
@@ -67,7 +67,7 @@ def download_rcc(location: str, force: bool = False) -> None:
                     else:
                         relative_path = "/linux32/rcc"
 
-                RCC_VERSION = "v11.2.0"
+                RCC_VERSION = "v11.3.2"
                 prefix = f"https://downloads.robocorp.com/rcc/releases/{RCC_VERSION}"
                 url = prefix + relative_path
 

--- a/robocorp-code/src/robocorp_code/rcc.py
+++ b/robocorp-code/src/robocorp_code/rcc.py
@@ -14,9 +14,11 @@ from robocorp_code.protocols import (
     ActionResult,
     IRobotYamlEnvInfo,
     IRccListener,
+    RobotTemplate,
 )
 from pathlib import Path
 import os.path
+import json
 from robocorp_ls_core.protocols import check_implements
 from dataclasses import dataclass
 import time
@@ -324,33 +326,25 @@ class Rcc(object):
         )
         return ActionResult(success=True, message=None, result=output)
 
-    _TEMPLATES = {
-        "standard": "Standard - Robot Framework Robot.",
-        "python": "Python - Python Robot.",
-        "extended": "Extended - Robot Framework Robot with additional scaffolding.",
-    }
-
     @implements(IRcc.get_template_names)
-    def get_template_names(self) -> ActionResult[List[str]]:
-        result = self._run_rcc("robot initialize -l".split())
+    def get_template_names(self) -> ActionResult[List[RobotTemplate]]:
+        result = self._run_rcc("robot initialize -l --json".split())
         if not result.success:
             return ActionResult(success=False, message=result.message)
 
-        output = result.result
+        output: Dict[str, str] = []
+        try:
+            output = json.loads(result.result)
+        except json.decoder.JSONDecodeError as e:
+            return ActionResult(success=False, message=f"Invalid output format: {e}")
         if output is None:
             return ActionResult(success=False, message="Output not available")
-        templates = set()
-        for line in output.splitlines():
-            if line.startswith("- "):
-                template_name = line[2:].strip()
-                templates.add(template_name)
+        templates: List[RobotTemplate] = []
+        for name, description in output.items():
+            template: RobotTemplate = {"name": name, "description": description}
+            templates.append(template)
 
-        ret: List[str] = []
-        for key, description in self._TEMPLATES.items():
-            if key in templates:
-                ret.append(description)
-
-        return ActionResult(success=True, message=None, result=ret)
+        return ActionResult(success=True, message=None, result=templates)
 
     def _add_config_to_args(self, args: List[str]) -> List[str]:
         config_location = self.config_location
@@ -377,13 +371,6 @@ class Rcc(object):
 
     @implements(IRcc.create_robot)
     def create_robot(self, template: str, directory: str) -> ActionResult:
-        if template not in self._TEMPLATES:
-            # Check if we can translate from the description
-            for key, description in self._TEMPLATES.items():
-                if description == template:
-                    template = key
-                    break
-
         args = ["robot", "initialize", "-t", template, "-d", directory]
         args = self._add_config_to_args(args)
         return self._run_rcc(args, error_msg="Error creating robot.")

--- a/robocorp-code/src/robocorp_code/rcc.py
+++ b/robocorp-code/src/robocorp_code/rcc.py
@@ -332,13 +332,14 @@ class Rcc(object):
         if not result.success:
             return ActionResult(success=False, message=result.message)
 
+        if result.result is None:
+            return ActionResult(success=False, message="Output not available")
+
         output: Dict[str, str] = []
         try:
             output = json.loads(result.result)
         except json.decoder.JSONDecodeError as e:
             return ActionResult(success=False, message=f"Invalid output format: {e}")
-        if output is None:
-            return ActionResult(success=False, message="Output not available")
         templates: List[RobotTemplate] = []
         for name, description in output.items():
             template: RobotTemplate = {"name": name, "description": description}

--- a/robocorp-code/tests/robocorp_code_tests/test_rcc.py
+++ b/robocorp-code/tests/robocorp_code_tests/test_rcc.py
@@ -18,7 +18,9 @@ def test_rcc_template_names(rcc: IRcc):
     result = rcc.get_template_names()
     assert result.success
     assert result.result
-    assert "Standard - Robot Framework Robot." in result.result
+    template_names = [template["name"] for template in result.result]
+    assert "standard" in template_names
+    assert "python" in template_names
 
 
 def test_rcc_cloud(rcc: IRcc, ci_credentials: str, tmpdir: py.path.local):

--- a/robocorp-code/tests/robocorp_code_tests/test_vscode_integration.py
+++ b/robocorp-code/tests/robocorp_code_tests/test_vscode_integration.py
@@ -95,11 +95,9 @@ def test_list_rcc_robot_templates(
         commands.ROBOCORP_LIST_ROBOT_TEMPLATES_INTERNAL, []
     )["result"]
     assert result["success"]
-    assert result["result"] == [
-        "Standard - Robot Framework Robot.",
-        "Python - Python Robot.",
-        "Extended - Robot Framework Robot with additional scaffolding.",
-    ]
+    template_names = [template["name"] for template in result["result"]]
+    assert "standard" in template_names
+    assert "python" in template_names
 
     target = str(tmpdir.join("dest"))
     language_server.change_workspace_folders(added_folders=[target], removed_folders=[])
@@ -110,7 +108,7 @@ def test_list_rcc_robot_templates(
             {
                 "directory": target,
                 "name": "example",
-                "template": "Standard - Robot Framework Robot.",
+                "template": template_names[0],
             }
         ],
     )["result"]
@@ -572,7 +570,7 @@ def test_hover_image_integration(
     uri = uris.from_fs_path(str(locators_json))
     txt = """
     "Image.Locator.01": {
-        "path": ".images/img1.png",    
+        "path": ".images/img1.png",
         "source": ".images/img1.png" """
     doc = Document("", txt)
     client.open_doc(uri, 1, txt)
@@ -763,7 +761,7 @@ def test_lint_robot_integration(
     robot_yaml_text = """
 tasks:
   Obtain environment information:
-    command: 
+    command:
       - python
       - get_env_info.py
 

--- a/robocorp-code/vscode-client/src/protocols.ts
+++ b/robocorp-code/vscode-client/src/protocols.ts
@@ -37,6 +37,11 @@ interface ListWorkspacesActionResult {
     result: WorkspaceInfo[];
 }
 
+interface RobotTemplate {
+    name: string;
+    description: string;
+}
+
 interface WorkItem {
     name: string;
     json_path: string;

--- a/robocorp-code/vscode-client/src/rcc.ts
+++ b/robocorp-code/vscode-client/src/rcc.ts
@@ -108,7 +108,7 @@ async function downloadRcc(
             relativePath = "/linux32/rcc";
         }
     }
-    const RCC_VERSION = "v11.2.0";
+    const RCC_VERSION = "v11.3.2";
     const prefix = "https://downloads.robocorp.com/rcc/releases/" + RCC_VERSION;
     const url: string = prefix + relativePath;
 


### PR DESCRIPTION
Update RCC to v11.3.2.

Get the template selection for creating a new robot from RCC.
RCC fetches the latest templates from remote repository, enabling dynamic updating for templates. And possibility to add more templates dynamically.