### PR TITLE
robotframework_ls: handle remote libraries import

### DIFF
--- a/.github/workflows/tests-robotframework-lsp.yml
+++ b/.github/workflows/tests-robotframework-lsp.yml
@@ -74,6 +74,8 @@ jobs:
     - name: Install robotframework from pip
       run: python -W ignore -m pip install "robotframework>=4.0"
       if: contains(matrix.name, '-pip-v4')
+    - name: Install robotremoteserver via pip
+      run: python -W ignore -m pip install robotremoteserver
     - name: Vendor robocorp_ls_core/robotframework_interactive
       working-directory: ./robotframework-ls
       run: |

--- a/robocorp-code/docs/develop.md
+++ b/robocorp-code/docs/develop.md
@@ -69,6 +69,7 @@ python -m venv .venv
 python -m pip install -r robocorp-code/tests/test_requirements.txt
 python -m pip install -r robocorp-code/dev_requirements.txt
 python -m pip install robotframework
+python -m pip install robotremoteserver
 echo %cd%\robotframework-ls\src > .venv\Lib\site-packages\rf_src.pth
 echo %cd%\robocorp-code\src >> .venv\Lib\site-packages\rf_src.pth
 echo %cd%\robocorp-python-ls-core\src >> .venv\Lib\site-packages\rf_src.pth
@@ -85,6 +86,7 @@ source ./.venv/bin/activate
 python -m pip install -r robocorp-code/tests/test_requirements.txt
 python -m pip install -r robocorp-code/dev_requirements.txt
 python -m pip install robotframework
+python -m pip install robotremoteserver
 echo $PWD/robotframework-ls/src > .venv/lib/python3.8/site-packages/rf_src.pth
 echo $PWD/robocorp-code/src >> .venv/lib/python3.8/site-packages/rf_src.pth
 echo $PWD/robocorp-python-ls-core/src >> .venv/lib/python3.8/site-packages/rf_src.pth

--- a/robotframework-ls/src/robotframework_ls/impl/ast_utils.py
+++ b/robotframework-ls/src/robotframework_ls/impl/ast_utils.py
@@ -667,3 +667,7 @@ def create_range_from_token(token):
     }
     code_lens_range: RangeTypedDict = {"start": start, "end": end}
     return code_lens_range
+
+
+def get_library_arguments_serialized(library) -> Optional[str]:
+    return "::".join(library.args) if library.args else None

--- a/robotframework-ls/src/robotframework_ls/impl/ast_utils.py
+++ b/robotframework-ls/src/robotframework_ls/impl/ast_utils.py
@@ -540,20 +540,6 @@ def get_keyword_name_token(ast, token):
     return None
 
 
-def is_remote_library_node(node) -> bool:
-    return node.name and node.name.lower() == "remote"
-
-
-def get_library_name_from_node(node) -> Optional[str]:
-    if not is_remote_library_node(node):
-        return node.name
-
-    if len(node.args) == 0:
-        return None
-
-    return "Remote::" + node.args[0]
-
-
 def get_library_import_name_token(ast, token):
     """
     If the given ast node is a library import and the token is its name, return
@@ -565,11 +551,7 @@ def get_library_import_name_token(ast, token):
         and isinstance_name(ast, "LibraryImport")
         and ast.name == token.value  # I.e.: match the name, not the alias.
     ):
-        token.value = get_library_name_from_node(ast)
-        if (
-            token.value
-        ):  # check if it was not `Library    Remote` without actual arguments
-            return token
+        return token
     return None
 
 

--- a/robotframework-ls/src/robotframework_ls/impl/ast_utils.py
+++ b/robotframework-ls/src/robotframework_ls/impl/ast_utils.py
@@ -540,6 +540,20 @@ def get_keyword_name_token(ast, token):
     return None
 
 
+def is_remote_library_node(node) -> bool:
+    return node.name and node.name.lower() == "remote"
+
+
+def get_library_name_from_node(node) -> Optional[str]:
+    if not is_remote_library_node(node):
+        return node.name
+
+    if len(node.args) == 0:
+        return None
+
+    return "Remote::" + node.args[0]
+
+
 def get_library_import_name_token(ast, token):
     """
     If the given ast node is a library import and the token is its name, return
@@ -551,7 +565,11 @@ def get_library_import_name_token(ast, token):
         and isinstance_name(ast, "LibraryImport")
         and ast.name == token.value  # I.e.: match the name, not the alias.
     ):
-        return token
+        token.value = get_library_name_from_node(ast)
+        if (
+            token.value
+        ):  # check if it was not `Library    Remote` without actual arguments
+            return token
     return None
 
 

--- a/robotframework-ls/src/robotframework_ls/impl/auto_import_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/auto_import_completions.py
@@ -301,13 +301,13 @@ def _obtain_import_location_info(completion_context) -> _ImportLocationInfo:
         if ast_utils.is_library_node_info(node_info):
             import_location_info.library_node_info = node_info
 
-            library_name = ast_utils.get_library_name_from_node(node_info.node)
+            library_name = node_info.node.name
             if library_name:
                 library_doc = libspec_manager.get_library_info(
                     completion_context.token_value_resolving_variables(library_name),
                     create=True,
                     current_doc_uri=completion_context.doc.uri,
-                    remote=ast_utils.is_remote_library_node(node_info.node),
+                    args="::".join(node_info.node.args),
                 )
                 if library_doc is not None:
                     if library_doc.source:

--- a/robotframework-ls/src/robotframework_ls/impl/auto_import_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/auto_import_completions.py
@@ -307,7 +307,7 @@ def _obtain_import_location_info(completion_context) -> _ImportLocationInfo:
                     completion_context.token_value_resolving_variables(library_name),
                     create=True,
                     current_doc_uri=completion_context.doc.uri,
-                    args="::".join(node_info.node.args),
+                    args=ast_utils.get_library_arguments_serialized(node_info.node),
                 )
                 if library_doc is not None:
                     if library_doc.source:

--- a/robotframework-ls/src/robotframework_ls/impl/auto_import_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/auto_import_completions.py
@@ -301,12 +301,13 @@ def _obtain_import_location_info(completion_context) -> _ImportLocationInfo:
         if ast_utils.is_library_node_info(node_info):
             import_location_info.library_node_info = node_info
 
-            library_name = node_info.node.name
+            library_name = ast_utils.get_library_name_from_node(node_info.node)
             if library_name:
                 library_doc = libspec_manager.get_library_info(
                     completion_context.token_value_resolving_variables(library_name),
                     create=True,
                     current_doc_uri=completion_context.doc.uri,
+                    remote=ast_utils.is_remote_library_node(node_info.node),
                 )
                 if library_doc is not None:
                     if library_doc.source:

--- a/robotframework-ls/src/robotframework_ls/impl/collect_keywords.py
+++ b/robotframework-ls/src/robotframework_ls/impl/collect_keywords.py
@@ -277,7 +277,7 @@ def _collect_libraries_keywords(
             (
                 library.name,
                 library.alias,
-                "::".join(library.args),
+                ast_utils.get_library_arguments_serialized(library),
             )
             for library in libraries
         )

--- a/robotframework-ls/src/robotframework_ls/impl/collect_keywords.py
+++ b/robotframework-ls/src/robotframework_ls/impl/collect_keywords.py
@@ -250,7 +250,7 @@ def _collect_current_doc_keywords(
     _collect_completions_from_ast(ast, completion_context, collector)
 
 
-_LibInfo = namedtuple("_LibInfo", "name, alias, builtin, remote")
+_LibInfo = namedtuple("_LibInfo", "name, alias, builtin, args")
 
 
 def _collect_libraries_keywords(
@@ -271,19 +271,19 @@ def _collect_libraries_keywords(
             completion_context.token_value_resolving_variables(name),
             alias,
             False,
-            remote,
+            args,
         )
-        for name, alias, remote in (
+        for name, alias, args in (
             (
-                ast_utils.get_library_name_from_node(library),
+                library.name,
                 library.alias,
-                ast_utils.is_remote_library_node(library),
+                "::".join(library.args),
             )
             for library in libraries
         )
         if name
     )
-    library_infos.add(_LibInfo(BUILTIN_LIB, None, True, False))
+    library_infos.add(_LibInfo(BUILTIN_LIB, None, True, None))
     libspec_manager = completion_context.workspace.libspec_manager
 
     for library_info in library_infos:
@@ -296,7 +296,7 @@ def _collect_libraries_keywords(
             create=True,
             current_doc_uri=completion_context.doc.uri,
             builtin=library_info.builtin,
-            remote=library_info.remote,
+            args=library_info.args,
         )
         if library_doc is not None:
             #: :type keyword: KeywordDoc

--- a/robotframework-ls/src/robotframework_ls/impl/collect_keywords.py
+++ b/robotframework-ls/src/robotframework_ls/impl/collect_keywords.py
@@ -250,7 +250,7 @@ def _collect_current_doc_keywords(
     _collect_completions_from_ast(ast, completion_context, collector)
 
 
-_LibInfo = namedtuple("_LibInfo", "name, alias, builtin")
+_LibInfo = namedtuple("_LibInfo", "name, alias, builtin, remote")
 
 
 def _collect_libraries_keywords(
@@ -262,18 +262,28 @@ def _collect_libraries_keywords(
     # Get keywords from libraries
     from robotframework_ls.impl.robot_constants import BUILTIN_LIB
     from robocorp_ls_core.lsp import CompletionItemKind
+    from robotframework_ls.impl import ast_utils
 
     libraries = completion_context.get_imported_libraries()
 
     library_infos = set(
         _LibInfo(
-            completion_context.token_value_resolving_variables(library.name),
-            library.alias,
+            completion_context.token_value_resolving_variables(name),
+            alias,
             False,
+            remote,
         )
-        for library in libraries
+        for name, alias, remote in (
+            (
+                ast_utils.get_library_name_from_node(library),
+                library.alias,
+                ast_utils.is_remote_library_node(library),
+            )
+            for library in libraries
+        )
+        if name
     )
-    library_infos.add(_LibInfo(BUILTIN_LIB, None, True))
+    library_infos.add(_LibInfo(BUILTIN_LIB, None, True, False))
     libspec_manager = completion_context.workspace.libspec_manager
 
     for library_info in library_infos:
@@ -286,6 +296,7 @@ def _collect_libraries_keywords(
             create=True,
             current_doc_uri=completion_context.doc.uri,
             builtin=library_info.builtin,
+            remote=library_info.remote,
         )
         if library_doc is not None:
             #: :type keyword: KeywordDoc

--- a/robotframework-ls/src/robotframework_ls/impl/find_definition.py
+++ b/robotframework-ls/src/robotframework_ls/impl/find_definition.py
@@ -237,6 +237,7 @@ def find_definition(completion_context: ICompletionContext) -> Sequence[IDefinit
                 completion_context.token_value_resolving_variables(token),
                 create=True,
                 current_doc_uri=completion_context.doc.uri,
+                remote=ast_utils.is_remote_library_node(token_info.node),
             )
             if library_doc is not None:
                 definition = _DefinitionFromLibrary(library_doc)

--- a/robotframework-ls/src/robotframework_ls/impl/find_definition.py
+++ b/robotframework-ls/src/robotframework_ls/impl/find_definition.py
@@ -237,7 +237,7 @@ def find_definition(completion_context: ICompletionContext) -> Sequence[IDefinit
                 completion_context.token_value_resolving_variables(token),
                 create=True,
                 current_doc_uri=completion_context.doc.uri,
-                remote=ast_utils.is_remote_library_node(token_info.node),
+                args="::".join(token_info.node.args),
             )
             if library_doc is not None:
                 definition = _DefinitionFromLibrary(library_doc)

--- a/robotframework-ls/src/robotframework_ls/impl/find_definition.py
+++ b/robotframework-ls/src/robotframework_ls/impl/find_definition.py
@@ -237,7 +237,7 @@ def find_definition(completion_context: ICompletionContext) -> Sequence[IDefinit
                 completion_context.token_value_resolving_variables(token),
                 create=True,
                 current_doc_uri=completion_context.doc.uri,
-                args="::".join(token_info.node.args),
+                args=ast_utils.get_library_arguments_serialized(token_info.node),
             )
             if library_doc is not None:
                 definition = _DefinitionFromLibrary(library_doc)

--- a/robotframework-ls/src/robotframework_ls/impl/libspec_manager.py
+++ b/robotframework-ls/src/robotframework_ls/impl/libspec_manager.py
@@ -872,8 +872,12 @@ class LibspecManager(object):
                 else:
                     import hashlib
 
-                    digest = hashlib.sha256(args.encode("utf-8", "replace")).hexdigest()[:8]
-                    libspec_filename = os.path.join(libspec_dir, libname + digest + ".libspec")
+                    digest = hashlib.sha256(
+                        args.encode("utf-8", "replace")
+                    ).hexdigest()[:8]
+                    libspec_filename = os.path.join(
+                        libspec_dir, libname + digest + ".libspec"
+                    )
 
                 log.debug(f"Obtaining mutex to generate libspec: {libspec_filename}.")
                 with timed_acquire_mutex(
@@ -1079,7 +1083,9 @@ class LibspecManager(object):
                 else:
                     import hashlib
 
-                    digest = hashlib.sha256(args.encode("utf-8", "replace")).hexdigest()[:8]
+                    digest = hashlib.sha256(
+                        args.encode("utf-8", "replace")
+                    ).hexdigest()[:8]
                     found = library_doc.filename.endswith(
                         os.path.normcase(libname + digest + ".libspec")
                     )

--- a/robotframework-ls/src/robotframework_ls/impl/libspec_manager.py
+++ b/robotframework-ls/src/robotframework_ls/impl/libspec_manager.py
@@ -30,6 +30,12 @@ def _get_additional_info_filename(spec_filename):
     return additional_info_filename
 
 
+def _get_digest_from_string(string):
+    import hashlib
+
+    return hashlib.sha256(string.encode("utf-8", "replace")).hexdigest()[:8]
+
+
 def _load_library_doc_and_mtime(spec_filename, obtain_mutex=True):
     """
     :param obtain_mutex:
@@ -860,21 +866,13 @@ class LibspecManager(object):
                     libspec_dir = self._builtins_libspec_dir
 
                 if target_file:
-                    import hashlib
-
-                    digest = hashlib.sha256(
-                        target_file.encode("utf-8", "replace")
-                    ).hexdigest()[:8]
+                    digest = _get_digest_from_string(target_file)
 
                     libspec_filename = os.path.join(libspec_dir, digest + ".libspec")
                 elif not args:
                     libspec_filename = os.path.join(libspec_dir, libname + ".libspec")
                 else:
-                    import hashlib
-
-                    digest = hashlib.sha256(
-                        args.encode("utf-8", "replace")
-                    ).hexdigest()[:8]
+                    digest = _get_digest_from_string(args)
                     libspec_filename = os.path.join(
                         libspec_dir, libname + digest + ".libspec"
                     )
@@ -1081,11 +1079,7 @@ class LibspecManager(object):
                         library_doc.name and library_doc.name.lower() == libname_lower
                     )
                 else:
-                    import hashlib
-
-                    digest = hashlib.sha256(
-                        args.encode("utf-8", "replace")
-                    ).hexdigest()[:8]
+                    digest = _get_digest_from_string(args)
                     found = library_doc.filename.endswith(
                         os.path.normcase(libname + digest + ".libspec")
                     )

--- a/robotframework-ls/tests/robotframework_ls_tests/_resources/case_remote_library/case_remote.robot
+++ b/robotframework-ls/tests/robotframework_ls_tests/_resources/case_remote_library/case_remote.robot
@@ -1,0 +1,5 @@
+*** Settings ***
+Library    Remote    http://127.0.0.1:${PORT}    WITH NAME    a
+
+*** Test Cases ***
+Simple test case

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_keyword_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_keyword_completions.py
@@ -713,3 +713,28 @@ Templated test case
 
     completions = keyword_completions.complete(completion_context)
     assert [comp["label"] for comp in completions] == ["Example Keyword"]
+
+
+@pytest.mark.parametrize(
+    "server_port",
+    [
+        8270,  # default port
+        0,  # let OS decide port
+    ],
+)
+def test_keyword_completions_remote_library(workspace, libspec_manager, remote_library):
+    from robotframework_ls.impl import keyword_completions
+    from robotframework_ls.impl.completion_context import CompletionContext
+
+    workspace.set_root("case_remote_library", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case_remote.robot")
+    doc.source = doc.source.replace("${PORT}", str(remote_library)) + "\n    a.V"
+
+    completion_context = CompletionContext(doc, workspace=workspace.ws)
+
+    completions = keyword_completions.complete(completion_context)
+    assert sorted([comp["label"] for comp in completions]) == [
+        "Stop Remote Server",
+        "Validate String",
+        "Verify That Remote Is Running",
+    ]

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_keyword_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_keyword_completions.py
@@ -738,3 +738,24 @@ def test_keyword_completions_remote_library(workspace, libspec_manager, remote_l
         "Validate String",
         "Verify That Remote Is Running",
     ]
+
+
+def test_keyword_completions_lirary_with_params_with_space(workspace, libspec_manager):
+    from robotframework_ls.impl import keyword_completions
+    from robotframework_ls.impl.completion_context import CompletionContext
+
+    workspace.set_root("case_params_on_lib", libspec_manager=libspec_manager)
+    doc = workspace.get_doc("case_params_on_lib.robot")
+    doc.source = """
+*** Settings ***
+Library    LibWithParams    some_param=foo bar    WITH NAME    Lib
+
+*** Test Case  ***
+My Test
+    Lib.Some"""
+
+    completion_context = CompletionContext(doc, workspace=workspace.ws)
+    completions = keyword_completions.complete(completion_context)
+
+    assert len(completions) == 1
+    assert sorted([comp["label"] for comp in completions]) == ["Some Method"]

--- a/robotframework-ls/tests/robotframework_ls_tests/fixtures.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/fixtures.py
@@ -317,3 +317,29 @@ def check_code_lens_data_regression(data_regression, found, basename=None):
             if uri:
                 data["uri"] = uri.split("/")[-1]
     data_regression.check(found, basename=basename)
+
+
+class RemoteLibraryExample(object):
+    def validate_string(self, string):
+        return True
+
+    def verify_that_remote_is_running(self):
+        return True
+
+
+@pytest.fixture
+def remote_library(server_port):
+    from robotremoteserver import RobotRemoteServer
+    import threading
+
+    server = RobotRemoteServer(
+        RemoteLibraryExample(),
+        port=server_port,
+        serve=False,
+    )
+    server.activate()
+    server_thread = threading.Thread(target=server.serve, args=(False,))
+    server_thread.start()
+    yield server.server_port
+    server.stop()
+    server_thread.join()


### PR DESCRIPTION
Now the libspec generation will be called with lib in format `<Library>::<arg0>::...::<argN>` to match what
LibDoc expects.

Fixes #343
Fixes #373 

Obligatory gif from Neovim:
![nvim_robot_lsp_remote_lib](https://user-images.githubusercontent.com/5606370/140649219-0ace9907-9ee1-4abe-b2c5-3217268fb48b.gif)
