### PR TITLE
Use the global launch template if present

### DIFF
--- a/robotframework-ls/vscode-client/src/run.ts
+++ b/robotframework-ls/vscode-client/src/run.ts
@@ -53,6 +53,10 @@ async function checkFileExists(file) {
 }
 
 async function readAllDebugConfigs(workspaceFolder: WorkspaceFolder): Promise<DebugConfiguration[]> {
+    const launch = workspace.getConfiguration("launch");
+    const configs = launch.inspect<DebugConfiguration[]>("configurations")?.globalValue;
+    if (configs) return configs;
+
     const filename = path.join(workspaceFolder.uri.fsPath, ".vscode", "launch.json");
     if (!(await checkFileExists(filename))) {
         return [];


### PR DESCRIPTION
A global launch template can be defined in the *launch* section of `settings.json`, but currently the RF LS extension ignores it. With this PR if a global launch template is defined, it takes precedence over the launch template in launch.json, as expected. If there is no global launch template, then the template in launch.json is used.