### PR TITLE
Add windows locator support for inspector

### DIFF
--- a/robocorp-code/bin/create_env/conda.yaml
+++ b/robocorp-code/bin/create_env/conda.yaml
@@ -4,6 +4,6 @@ dependencies:
   - python=3.8.10
   - pip=20.1
   - pip:
-    - robocorp-inspector==0.5.0
+    - robocorp-inspector==0.6.0
     - robotframework==4.1
 

--- a/robocorp-code/bin/create_env/conda_vscode_darwin_amd64.yaml
+++ b/robocorp-code/bin/create_env/conda_vscode_darwin_amd64.yaml
@@ -12,5 +12,5 @@ dependencies:
   - python.app=1.3
 
   - pip:
-    - robocorp-inspector==0.5.0
+    - robocorp-inspector==0.6.0
     - robotframework==4.1

--- a/robocorp-code/bin/create_env/conda_vscode_linux_amd64.yaml
+++ b/robocorp-code/bin/create_env/conda_vscode_linux_amd64.yaml
@@ -12,5 +12,5 @@ dependencies:
   - pyqt=5.12.3
 
   - pip:
-    - robocorp-inspector==0.5.0
+    - robocorp-inspector==0.6.0
     - robotframework==4.1

--- a/robocorp-code/bin/create_env/conda_vscode_windows_amd64.yaml
+++ b/robocorp-code/bin/create_env/conda_vscode_windows_amd64.yaml
@@ -6,7 +6,8 @@ dependencies:
 
   # https://pip.pypa.io/en/stable/news/
   - pip=20.1
+  - pywin32=303
 
   - pip:
-    - robocorp-inspector==0.5.0
+    - robocorp-inspector==0.6.0
     - robotframework==4.1

--- a/robocorp-code/codegen/commands.py
+++ b/robocorp-code/codegen/commands.py
@@ -1,4 +1,5 @@
 from convert import convert_case_to_constant
+import os
 
 
 class Command(object):
@@ -307,6 +308,13 @@ COMMANDS = [
         add_to_package_json=True,
         server_handled=False,
         icon="$(desktop-download)",
+    ),
+    Command(
+        "robocorp.newRobocorpInspectorWindows",
+        "Add Windows Locator",
+        add_to_package_json=True,
+        server_handled=False,
+        icon="$(window)",
     ),
     Command(
         "robocorp.editRobocorpInspectorLocator",

--- a/robocorp-code/codegen/commands.py
+++ b/robocorp-code/codegen/commands.py
@@ -1,5 +1,6 @@
 from convert import convert_case_to_constant
 
+
 class Command(object):
     def __init__(
         self,

--- a/robocorp-code/codegen/commands.py
+++ b/robocorp-code/codegen/commands.py
@@ -1,6 +1,4 @@
 from convert import convert_case_to_constant
-import os
-
 
 class Command(object):
     def __init__(

--- a/robocorp-code/codegen/views.py
+++ b/robocorp-code/codegen/views.py
@@ -188,6 +188,11 @@ TREE_VIEW_CONTAINERS = [
                             MenuGroup.NAVIGATION,
                             "robocorp-code:single-robot-selected",
                         ),
+                        Menu(
+                            "robocorp.newRobocorpInspectorWindows",
+                            MenuGroup.NAVIGATION,
+                            "robocorp-code:single-robot-selected",
+                        ),
                     ],
                     "view/item/context": [
                         Menu(

--- a/robocorp-code/package.json
+++ b/robocorp-code/package.json
@@ -59,6 +59,7 @@
         "onCommand:robocorp.openCloudHome",
         "onCommand:robocorp.newRobocorpInspectorBrowser",
         "onCommand:robocorp.newRobocorpInspectorImage",
+        "onCommand:robocorp.newRobocorpInspectorWindows",
         "onCommand:robocorp.editRobocorpInspectorLocator",
         "onCommand:robocorp.copyLocatorToClipboard.internal",
         "onCommand:robocorp.openRobotTreeSelection",
@@ -368,6 +369,12 @@
                 "icon": "$(desktop-download)"
             },
             {
+                "command": "robocorp.newRobocorpInspectorWindows",
+                "title": "Add Windows Locator",
+                "category": "Robocorp",
+                "icon": "$(window)"
+            },
+            {
                 "command": "robocorp.editRobocorpInspectorLocator",
                 "title": "Edit locator",
                 "category": "Robocorp",
@@ -558,6 +565,11 @@
                 },
                 {
                     "command": "robocorp.newRobocorpInspectorImage",
+                    "when": "view == robocorp-locators-tree && robocorp-code:single-robot-selected",
+                    "group": "navigation"
+                },
+                {
+                    "command": "robocorp.newRobocorpInspectorWindows",
                     "when": "view == robocorp-locators-tree && robocorp-code:single-robot-selected",
                     "group": "navigation"
                 },

--- a/robocorp-code/src/robocorp_code/commands.py
+++ b/robocorp-code/src/robocorp_code/commands.py
@@ -41,6 +41,7 @@ ROBOCORP_REMOVE_LOCATOR_FROM_JSON = "robocorp.removeLocatorFromJson"  # Remove L
 ROBOCORP_OPEN_CLOUD_HOME = "robocorp.openCloudHome"  # Open cloud home
 ROBOCORP_NEW_ROBOCORP_INSPECTOR_BROWSER = "robocorp.newRobocorpInspectorBrowser"  # Add Browser Locator
 ROBOCORP_NEW_ROBOCORP_INSPECTOR_IMAGE = "robocorp.newRobocorpInspectorImage"  # Add Image Locator
+ROBOCORP_NEW_ROBOCORP_INSPECTOR_WINDOWS = "robocorp.newRobocorpInspectorWindows"  # Add Windows Locator
 ROBOCORP_EDIT_ROBOCORP_INSPECTOR_LOCATOR = "robocorp.editRobocorpInspectorLocator"  # Edit locator
 ROBOCORP_COPY_LOCATOR_TO_CLIPBOARD_INTERNAL = "robocorp.copyLocatorToClipboard.internal"  # Copy locator name to clipboard
 ROBOCORP_OPEN_ROBOT_TREE_SELECTION = "robocorp.openRobotTreeSelection"  # Open robot.yaml

--- a/robocorp-code/vscode-client/src/extension.ts
+++ b/robocorp-code/vscode-client/src/extension.ts
@@ -114,6 +114,7 @@ import {
     ROBOCORP_DISCONNECT_VAULT,
     ROBOCORP_OPEN_VAULT_HELP,
     ROBOCORP_CLEAR_ENV_AND_RESTART,
+    ROBOCORP_NEW_ROBOCORP_INSPECTOR_WINDOWS,
 } from "./robocorpCommands";
 import { installPythonInterpreterCheck } from "./pythonExtIntegration";
 import { refreshCloudTreeView } from "./viewsRobocorp";
@@ -326,6 +327,7 @@ function registerRobocorpCodeCommands(C: CommandRegistry) {
     );
     C.register(ROBOCORP_NEW_ROBOCORP_INSPECTOR_BROWSER, () => inspector.openRobocorpInspector("browser"));
     C.register(ROBOCORP_NEW_ROBOCORP_INSPECTOR_IMAGE, () => inspector.openRobocorpInspector("image"));
+    C.register(ROBOCORP_NEW_ROBOCORP_INSPECTOR_WINDOWS, () => inspector.openRobocorpInspector("windows"));
     C.register(ROBOCORP_COPY_LOCATOR_TO_CLIPBOARD_INTERNAL, (locator?: LocatorEntry) =>
         copySelectedToClipboard(locator)
     );

--- a/robocorp-code/vscode-client/src/inspector.ts
+++ b/robocorp-code/vscode-client/src/inspector.ts
@@ -12,6 +12,13 @@ let _openingInspector: boolean = false;
 let _startingRootWindowNotified: boolean = false;
 
 export async function openRobocorpInspector(locatorType?: string, locator?: LocatorEntry): Promise<void> {
+    if (locatorType === "windows" && process.platform !== "win32") {
+        window.showInformationMessage(
+            "This feature is Windows specific and not supported on other platforms."
+        );
+        return; // Windows only feature
+    }
+
     if (_openingInspector) {
         if (!_startingRootWindowNotified) {
             return; // We should be showing the progress already, so, don't do anything.

--- a/robocorp-code/vscode-client/src/inspector.ts
+++ b/robocorp-code/vscode-client/src/inspector.ts
@@ -13,9 +13,7 @@ let _startingRootWindowNotified: boolean = false;
 
 export async function openRobocorpInspector(locatorType?: string, locator?: LocatorEntry): Promise<void> {
     if (locatorType === "windows" && process.platform !== "win32") {
-        window.showInformationMessage(
-            "This feature is Windows specific and not supported on other platforms."
-        );
+        window.showInformationMessage("This feature is Windows specific and not supported on other platforms.");
         return; // Windows only feature
     }
 

--- a/robocorp-code/vscode-client/src/robocorpCommands.ts
+++ b/robocorp-code/vscode-client/src/robocorpCommands.ts
@@ -40,6 +40,7 @@ export const ROBOCORP_REMOVE_LOCATOR_FROM_JSON = "robocorp.removeLocatorFromJson
 export const ROBOCORP_OPEN_CLOUD_HOME = "robocorp.openCloudHome";  // Open cloud home
 export const ROBOCORP_NEW_ROBOCORP_INSPECTOR_BROWSER = "robocorp.newRobocorpInspectorBrowser";  // Add Browser Locator
 export const ROBOCORP_NEW_ROBOCORP_INSPECTOR_IMAGE = "robocorp.newRobocorpInspectorImage";  // Add Image Locator
+export const ROBOCORP_NEW_ROBOCORP_INSPECTOR_WINDOWS = "robocorp.newRobocorpInspectorWindows";  // Add Windows Locator
 export const ROBOCORP_EDIT_ROBOCORP_INSPECTOR_LOCATOR = "robocorp.editRobocorpInspectorLocator";  // Edit locator
 export const ROBOCORP_COPY_LOCATOR_TO_CLIPBOARD_INTERNAL = "robocorp.copyLocatorToClipboard.internal";  // Copy locator name to clipboard
 export const ROBOCORP_OPEN_ROBOT_TREE_SELECTION = "robocorp.openRobotTreeSelection";  // Open robot.yaml


### PR DESCRIPTION
Update the robocorp-inspector to latest version (0.6.0).
New locator menu item: Add Windows locator.

@fabioz do we have any option to disable a menu item / command in certain platforms? This feature in inspector is Windows only. I added an error message for the user, but of course it would be better if the menu item is disabled.