### PR TITLE
CONV-139 Download converter commons and use convertyml when calling converter

### DIFF
--- a/robocorp-code/codegen/codegen_package.py
+++ b/robocorp-code/codegen/codegen_package.py
@@ -132,6 +132,8 @@ def get_json_contents():
             "@types/mocha": "^2.2.32",
             "@types/node": "^13.0.00",
             "@types/vscode": "1.65.0",
+            "@types/adm-zip": "^0.5.0",
+            "@types/rimraf": "^3.0.2",
             "prettier": "2.4.1",
             "vscode-test": "1.5.1",
             "typescript": "^4.5.4",
@@ -142,6 +144,8 @@ def get_json_contents():
             "http-proxy-agent": "^2.1.0",
             "https-proxy-agent": "^2.2.4",
             "vscode-nls": "^4.1.2",
+            "adm-zip": "^0.5.9",
+            "rimraf": "^3.0.2",
         },
     }
     return base_package_contents

--- a/robocorp-code/package.json
+++ b/robocorp-code/package.json
@@ -955,22 +955,22 @@
         "prettier-fix": "npx prettier -w vscode-client/**/*.ts"
     },
     "devDependencies": {
-        "@types/adm-zip": "^0.5.0",
         "@types/mocha": "^2.2.32",
         "@types/node": "^13.0.00",
-        "@types/rimraf": "^3.0.2",
         "@types/vscode": "1.65.0",
+        "@types/adm-zip": "^0.5.0",
+        "@types/rimraf": "^3.0.2",
         "prettier": "2.4.1",
-        "typescript": "^4.5.4",
-        "vscode-test": "1.5.1"
+        "vscode-test": "1.5.1",
+        "typescript": "^4.5.4"
     },
     "dependencies": {
-        "adm-zip": "^0.5.9",
+        "vscode-languageclient": "^7.0.0",
+        "path-exists": "^4.0.0",
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.4",
-        "path-exists": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "vscode-languageclient": "^7.0.0",
-        "vscode-nls": "^4.1.2"
+        "vscode-nls": "^4.1.2",
+        "adm-zip": "^0.5.9",
+        "rimraf": "^3.0.2"
     }
 }

--- a/robocorp-code/package.json
+++ b/robocorp-code/package.json
@@ -955,18 +955,22 @@
         "prettier-fix": "npx prettier -w vscode-client/**/*.ts"
     },
     "devDependencies": {
+        "@types/adm-zip": "^0.5.0",
         "@types/mocha": "^2.2.32",
         "@types/node": "^13.0.00",
+        "@types/rimraf": "^3.0.2",
         "@types/vscode": "1.65.0",
         "prettier": "2.4.1",
-        "vscode-test": "1.5.1",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.4",
+        "vscode-test": "1.5.1"
     },
     "dependencies": {
-        "vscode-languageclient": "^7.0.0",
-        "path-exists": "^4.0.0",
+        "adm-zip": "^0.5.9",
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.4",
+        "path-exists": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "vscode-languageclient": "^7.0.0",
         "vscode-nls": "^4.1.2"
     }
 }

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -1,7 +1,7 @@
 import * as AdmZip from "adm-zip";
 import * as rimraf from "rimraf";
 
-import * as path from 'path';
+import * as path from "path";
 
 import { window, Progress, ProgressLocation, CancellationToken } from "vscode";
 import { getExtensionRelativeFile, readFromFile, verifyFileExists, writeToFile } from "./files";
@@ -78,7 +78,7 @@ export async function ensureConvertBundle(): Promise<{
 
         const zip = new AdmZip(bundleLocation);
         zip.extractAllTo(bundleFolderLocation);
-    }
+    };
 
     // if the bundle file doesn't exit or isn't marked as being downloaded, force download
     const warnUser: boolean = false;
@@ -101,14 +101,13 @@ export async function ensureConvertBundle(): Promise<{
                 await downloadBundle();
                 await unzipCommons();
             }
-           
         }
     }
 
     // TODO simplify nesting
-    const executable = path.join(bundleFolderLocation, 'converter-with-commons', 'bundle.js');
-    const convertYaml = path.join(bundleFolderLocation, 'converter-with-commons', 'robocorp-commons', 'convert.yaml');
-    
+    const executable = path.join(bundleFolderLocation, "converter-with-commons", "bundle.js");
+    const convertYaml = path.join(bundleFolderLocation, "converter-with-commons", "robocorp-commons", "convert.yaml");
+
     return {
         pathToExecutable: executable,
         pathToConvertYaml: verifyFileExists(convertYaml) ? convertYaml : undefined,

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as AdmZip from "adm-zip";
-import * as rimraf from 'rimraf'
+import * as rimraf from "rimraf";
 
 import { window, Progress, ProgressLocation, CancellationToken } from "vscode";
 import { getExtensionRelativeFile, readFromFile, verifyFileExists, writeToFile } from "./files";
@@ -96,15 +96,20 @@ export async function ensureConvertBundle(): Promise<string> {
     return bundleLocation;
 }
 
-
 export const getRobocorpCommonsVersion = async (): Promise<{
     currentVersion?: string;
     newVersion?: string;
     currentVersionLocation?: string;
 }> => {
     const versionURL = "https://downloads.robocorp.com/converter/commons/version.txt";
-    const currentVersionLocation = getExtensionRelativeFile("../../vscode-client/out/robocorp-bp-commons.version", false);
-    const newVersionLocation = getExtensionRelativeFile("../../vscode-client/out/robocorp-bp-commons.version.new", false);
+    const currentVersionLocation = getExtensionRelativeFile(
+        "../../vscode-client/out/robocorp-bp-commons.version",
+        false
+    );
+    const newVersionLocation = getExtensionRelativeFile(
+        "../../vscode-client/out/robocorp-bp-commons.version.new",
+        false
+    );
 
     const currentVersion = await readFromFile(currentVersionLocation);
     let newVersion = undefined;
@@ -131,10 +136,9 @@ export const getRobocorpCommonsVersion = async (): Promise<{
     return { currentVersion: currentVersion, newVersion: newVersion, currentVersionLocation: currentVersionLocation };
 };
 
-
 export async function ensureRobocorpCommons(): Promise<string | undefined> {
-    const converterHome = path.join(getHome(), 'converter');
-    const robocorpBpCommonLocation = path.join(converterHome, 'robocorp-bp-common');
+    const converterHome = path.join(getHome(), "converter");
+    const robocorpBpCommonLocation = path.join(converterHome, "robocorp-bp-common");
 
     // common zip
     const commonsURL = "https://downloads.robocorp.com/converter/commons/robocorp-bp-commons.zip";
@@ -142,7 +146,7 @@ export async function ensureRobocorpCommons(): Promise<string | undefined> {
     const commonZipLocation = getExtensionRelativeFile(commonsZipRelativeLocation, false);
 
     // location of convert.yaml
-    const convertYamlLocation = path.join(robocorpBpCommonLocation, 'convert.yaml');
+    const convertYamlLocation = path.join(robocorpBpCommonLocation, "convert.yaml");
 
     const downloadCommons = async () =>
         await window.withProgress(
@@ -169,14 +173,14 @@ export async function ensureRobocorpCommons(): Promise<string | undefined> {
                 token: CancellationToken
             ): Promise<void> => {
                 if (verifyFileExists(robocorpBpCommonLocation, false)) {
-                    rimraf.sync(robocorpBpCommonLocation)
+                    rimraf.sync(robocorpBpCommonLocation);
                 }
 
                 await fs.promises.mkdir(robocorpBpCommonLocation, { recursive: true });
 
                 const zip = new AdmZip(commonZipLocation);
                 zip.extractAllTo(robocorpBpCommonLocation);
-            } 
+            }
         );
 
     if (!verifyFileExists(convertYamlLocation, false)) {
@@ -198,7 +202,6 @@ export async function ensureRobocorpCommons(): Promise<string | undefined> {
                 await downloadCommons();
                 await unzipCommons();
             }
-           
         }
     }
 

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -70,7 +70,7 @@ export async function ensureConvertBundle(): Promise<{
             ): Promise<string | undefined> => await download(bundleURL, progress, token, bundleLocation)
         );
 
-    const unzipCommons = async () => {
+    const unzipBundle = async () => {
         // remove previous bundle if it exists
         if (verifyFileExists(bundleFolderLocation, false)) {
             rimraf.sync(bundleFolderLocation);
@@ -84,7 +84,7 @@ export async function ensureConvertBundle(): Promise<{
     const warnUser: boolean = false;
     if (!verifyFileExists(bundleLocation, warnUser)) {
         await downloadBundle();
-        await unzipCommons();
+        await unzipBundle();
     } else if (!CONVERSION_STATUS.alreadyCheckedVersion) {
         CONVERSION_STATUS.alreadyCheckedVersion = true;
         const { currentVersion, newVersion, currentVersionLocation } = await getConverterBundleVersion();
@@ -99,7 +99,7 @@ export async function ensureConvertBundle(): Promise<{
             if (shouldUpgrade && shouldUpgrade !== "No") {
                 await writeToFile(currentVersionLocation, newVersion);
                 await downloadBundle();
-                await unzipCommons();
+                await unzipBundle();
             }
         }
     }

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -104,9 +104,8 @@ export async function ensureConvertBundle(): Promise<{
         }
     }
 
-    // TODO simplify nesting
-    const executable = path.join(bundleFolderLocation, "converter-with-commons", "bundle.js");
-    const convertYaml = path.join(bundleFolderLocation, "converter-with-commons", "robocorp-commons", "convert.yaml");
+    const executable = path.join(bundleFolderLocation, "bundle.js");
+    const convertYaml = path.join(bundleFolderLocation, "robocorp-commons", "convert.yaml");
 
     return {
         pathToExecutable: executable,

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -1,8 +1,18 @@
+import * as path from "path";
+import * as fs from "fs";
+import * as AdmZip from "adm-zip";
+import * as rimraf from 'rimraf'
+
 import { window, Progress, ProgressLocation, CancellationToken } from "vscode";
 import { getExtensionRelativeFile, readFromFile, verifyFileExists, writeToFile } from "./files";
 import { download } from "./rcc";
+import { getHome } from "./robocorpSettings";
 
 export const CONVERSION_STATUS = {
+    alreadyCheckedVersion: false,
+};
+
+export const ROBOCORP_COMMONS_STATUS = {
     alreadyCheckedVersion: false,
 };
 
@@ -84,4 +94,113 @@ export async function ensureConvertBundle(): Promise<string> {
         }
     }
     return bundleLocation;
+}
+
+
+export const getRobocorpCommonsVersion = async (): Promise<{
+    currentVersion?: string;
+    newVersion?: string;
+    currentVersionLocation?: string;
+}> => {
+    const versionURL = "https://downloads.robocorp.com/converter/commons/version.txt";
+    const currentVersionLocation = getExtensionRelativeFile("../../vscode-client/out/commons.version", false);
+    const newVersionLocation = getExtensionRelativeFile("../../vscode-client/out/commons.version.new", false);
+
+    const currentVersion = await readFromFile(currentVersionLocation);
+    let newVersion = undefined;
+    await window.withProgress(
+        {
+            location: ProgressLocation.Notification,
+            title: "Checking Robocorp commons version",
+            cancellable: false,
+        },
+        async (
+            progress: Progress<{ message?: string; increment?: number }>,
+            token: CancellationToken
+        ): Promise<string | undefined> => {
+            const result = await download(
+                versionURL,
+                progress,
+                token,
+                currentVersion ? newVersionLocation : currentVersionLocation
+            );
+            newVersion = await readFromFile(currentVersion ? newVersionLocation : currentVersionLocation);
+            return result;
+        }
+    );
+    return { currentVersion: currentVersion, newVersion: newVersion, currentVersionLocation: currentVersionLocation };
+};
+
+
+export async function ensureRobocorpCommons(): Promise<string> {
+    const converterHome = path.join(getHome(), 'converter');
+    const robocorpBpCommonLocation = path.join(converterHome, 'robocorp-bp-common');
+
+    // common zip
+    const commonsURL = "https://downloads.robocorp.com/converter/commons/robocorp-bp-commons.zip";
+    const commonsZipRelativeLocation = "../../vscode-client/out/robocorp-bp-commons.zip";
+    const commonZipLocation = getExtensionRelativeFile(commonsZipRelativeLocation, false);
+
+    // location of convert.yaml
+    const convertYamlLocation = path.join(robocorpBpCommonLocation, 'convert.yaml');
+
+    const downloadCommons = async () =>
+        await window.withProgress(
+            {
+                location: ProgressLocation.Notification,
+                title: "Downloading Robocorp commons",
+                cancellable: false,
+            },
+            async (
+                progress: Progress<{ message?: string; increment?: number }>,
+                token: CancellationToken
+            ): Promise<string | undefined> => await download(commonsURL, progress, token, commonZipLocation)
+        );
+
+    const unzipCommons = async () =>
+        await window.withProgress(
+            {
+                location: ProgressLocation.Notification,
+                title: "Unzipping Robocorp commons",
+                cancellable: false,
+            },
+            async (
+                progress: Progress<{ message?: string; increment?: number }>,
+                token: CancellationToken
+            ): Promise<void> => {
+                if (verifyFileExists(robocorpBpCommonLocation, false)) {
+                    rimraf.sync(robocorpBpCommonLocation)
+                }
+
+                await fs.promises.mkdir(robocorpBpCommonLocation, { recursive: true });
+
+                const zip = new AdmZip(commonZipLocation);
+                zip.extractAllTo(robocorpBpCommonLocation);
+            } 
+        );
+
+    const warnUser: boolean = false;
+    if (!verifyFileExists(convertYamlLocation, warnUser)) {
+        await downloadCommons();
+    } else if (!ROBOCORP_COMMONS_STATUS.alreadyCheckedVersion) {
+        ROBOCORP_COMMONS_STATUS.alreadyCheckedVersion = true;
+        const { currentVersion, newVersion, currentVersionLocation } = await getRobocorpCommonsVersion();
+        if (currentVersion && newVersion && currentVersion !== newVersion) {
+            // ask user if we should download the new version of the commons or use old one
+            const items = ["Yes", "No"];
+            const shouldUpgrade = await window.showQuickPick(items, {
+                "placeHolder": `Would you like to update Robocorp commons to version: ${newVersion}?`,
+                "canPickMany": false,
+                "ignoreFocusOut": true,
+            });
+            if (!shouldUpgrade || shouldUpgrade === "No") {
+                // do not continue with download & use current version
+                return convertYamlLocation;
+            }
+            await writeToFile(currentVersionLocation, newVersion);
+            await downloadCommons();
+            await unzipCommons();
+        }
+    }
+    return convertYamlLocation;
 }

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -1,18 +1,13 @@
-import * as path from "path";
-import * as fs from "fs";
 import * as AdmZip from "adm-zip";
 import * as rimraf from "rimraf";
+
+import * as path from 'path';
 
 import { window, Progress, ProgressLocation, CancellationToken } from "vscode";
 import { getExtensionRelativeFile, readFromFile, verifyFileExists, writeToFile } from "./files";
 import { download } from "./rcc";
-import { getHome } from "./robocorpSettings";
 
 export const CONVERSION_STATUS = {
-    alreadyCheckedVersion: false,
-};
-
-export const ROBOCORP_COMMONS_STATUS = {
     alreadyCheckedVersion: false,
 };
 
@@ -51,10 +46,15 @@ export const getConverterBundleVersion = async (): Promise<{
     return { currentVersion: currentVersion, newVersion: newVersion, currentVersionLocation: currentVersionLocation };
 };
 
-export async function ensureConvertBundle(): Promise<string> {
-    const bundleURL = "https://downloads.robocorp.com/converter/latest/bundle.js";
-    const bundleRelativeLocation = "../../vscode-client/out/converterBundle.js";
+export async function ensureConvertBundle(): Promise<{
+    pathToExecutable: string;
+    pathToConvertYaml?: string;
+}> {
+    const bundleURL = "https://downloads.robocorp.com/converter/latest/converter-with-commons.zip";
+    const bundleRelativeLocation = "../../vscode-client/out/converter-with-commons.zip";
     const bundleLocation = getExtensionRelativeFile(bundleRelativeLocation, false);
+    const bundleFolderRelativeLocation = "../../vscode-client/out/converter-with-commons";
+    const bundleFolderLocation = getExtensionRelativeFile(bundleFolderRelativeLocation, false);
 
     // downloading the bundle
     const downloadBundle = async () =>
@@ -70,10 +70,21 @@ export async function ensureConvertBundle(): Promise<string> {
             ): Promise<string | undefined> => await download(bundleURL, progress, token, bundleLocation)
         );
 
+    const unzipCommons = async () => {
+        // remove previous bundle if it exists
+        if (verifyFileExists(bundleFolderLocation, false)) {
+            rimraf.sync(bundleFolderLocation);
+        }
+
+        const zip = new AdmZip(bundleLocation);
+        zip.extractAllTo(bundleFolderLocation);
+    }
+
     // if the bundle file doesn't exit or isn't marked as being downloaded, force download
     const warnUser: boolean = false;
     if (!verifyFileExists(bundleLocation, warnUser)) {
         await downloadBundle();
+        await unzipCommons();
     } else if (!CONVERSION_STATUS.alreadyCheckedVersion) {
         CONVERSION_STATUS.alreadyCheckedVersion = true;
         const { currentVersion, newVersion, currentVersionLocation } = await getConverterBundleVersion();
@@ -85,131 +96,21 @@ export async function ensureConvertBundle(): Promise<string> {
                 "canPickMany": false,
                 "ignoreFocusOut": true,
             });
-            if (!shouldUpgrade || shouldUpgrade === "No") {
-                // do not continue with download & use current version
-                return bundleLocation;
-            }
-            await writeToFile(currentVersionLocation, newVersion);
-            await downloadBundle();
-        }
-    }
-    return bundleLocation;
-}
-
-export const getRobocorpCommonsVersion = async (): Promise<{
-    currentVersion?: string;
-    newVersion?: string;
-    currentVersionLocation?: string;
-}> => {
-    const versionURL = "https://downloads.robocorp.com/converter/commons/version.txt";
-    const currentVersionLocation = getExtensionRelativeFile(
-        "../../vscode-client/out/robocorp-bp-commons.version",
-        false
-    );
-    const newVersionLocation = getExtensionRelativeFile(
-        "../../vscode-client/out/robocorp-bp-commons.version.new",
-        false
-    );
-
-    const currentVersion = await readFromFile(currentVersionLocation);
-    let newVersion = undefined;
-    await window.withProgress(
-        {
-            location: ProgressLocation.Notification,
-            title: "Checking Robocorp commons version",
-            cancellable: false,
-        },
-        async (
-            progress: Progress<{ message?: string; increment?: number }>,
-            token: CancellationToken
-        ): Promise<string | undefined> => {
-            const result = await download(
-                versionURL,
-                progress,
-                token,
-                currentVersion ? newVersionLocation : currentVersionLocation
-            );
-            newVersion = await readFromFile(currentVersion ? newVersionLocation : currentVersionLocation);
-            return result;
-        }
-    );
-    return { currentVersion: currentVersion, newVersion: newVersion, currentVersionLocation: currentVersionLocation };
-};
-
-export async function ensureRobocorpCommons(): Promise<string | undefined> {
-    const converterHome = path.join(getHome(), "converter");
-    const robocorpBpCommonLocation = path.join(converterHome, "robocorp-bp-common");
-
-    // common zip
-    const commonsURL = "https://downloads.robocorp.com/converter/commons/robocorp-bp-commons.zip";
-    const commonsZipRelativeLocation = "../../vscode-client/out/robocorp-bp-commons.zip";
-    const commonZipLocation = getExtensionRelativeFile(commonsZipRelativeLocation, false);
-
-    // location of convert.yaml
-    const convertYamlLocation = path.join(robocorpBpCommonLocation, "convert.yaml");
-
-    const downloadCommons = async () =>
-        await window.withProgress(
-            {
-                location: ProgressLocation.Notification,
-                title: "Downloading Robocorp commons",
-                cancellable: false,
-            },
-            async (
-                progress: Progress<{ message?: string; increment?: number }>,
-                token: CancellationToken
-            ): Promise<string | undefined> => await download(commonsURL, progress, token, commonZipLocation)
-        );
-
-    const unzipCommons = async () =>
-        await window.withProgress(
-            {
-                location: ProgressLocation.Notification,
-                title: "Unzipping Robocorp commons",
-                cancellable: false,
-            },
-            async (
-                progress: Progress<{ message?: string; increment?: number }>,
-                token: CancellationToken
-            ): Promise<void> => {
-                if (verifyFileExists(robocorpBpCommonLocation, false)) {
-                    rimraf.sync(robocorpBpCommonLocation);
-                }
-
-                await fs.promises.mkdir(robocorpBpCommonLocation, { recursive: true });
-
-                const zip = new AdmZip(commonZipLocation);
-                zip.extractAllTo(robocorpBpCommonLocation);
-            }
-        );
-
-    if (!verifyFileExists(convertYamlLocation, false)) {
-        await downloadCommons();
-        await unzipCommons();
-    } else if (!ROBOCORP_COMMONS_STATUS.alreadyCheckedVersion) {
-        ROBOCORP_COMMONS_STATUS.alreadyCheckedVersion = true;
-        const { currentVersion, newVersion, currentVersionLocation } = await getRobocorpCommonsVersion();
-        if (currentVersion && newVersion && currentVersion !== newVersion) {
-            // ask user if we should download the new version of the commons or use old one
-            const items = ["Yes", "No"];
-            const shouldUpgrade = await window.showQuickPick(items, {
-                "placeHolder": `Would you like to update Robocorp commons to version: ${newVersion}?`,
-                "canPickMany": false,
-                "ignoreFocusOut": true,
-            });
             if (shouldUpgrade && shouldUpgrade !== "No") {
                 await writeToFile(currentVersionLocation, newVersion);
-                await downloadCommons();
+                await downloadBundle();
                 await unzipCommons();
             }
+           
         }
     }
 
-    if (!verifyFileExists(convertYamlLocation, false)) {
-        // something bad happened, just return undefined
-        // in this way the converter won't try to use any common model
-        return undefined;
-    }
-
-    return convertYamlLocation;
+    // TODO simplify nesting
+    const executable = path.join(bundleFolderLocation, 'converter-with-commons', 'bundle.js');
+    const convertYaml = path.join(bundleFolderLocation, 'converter-with-commons', 'robocorp-commons', 'convert.yaml');
+    
+    return {
+        pathToExecutable: executable,
+        pathToConvertYaml: verifyFileExists(convertYaml) ? convertYaml : undefined,
+    };
 }

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -16,7 +16,7 @@ export const getConverterBundleVersion = async (): Promise<{
     newVersion?: string;
     currentVersionLocation?: string;
 }> => {
-    const versionURL = "https://downloads.robocorp.com/converter/latest/version.txt";
+    const versionURL = "https://downloads.robocorp.com/converter/latest/version-with-commons.txt";
     const currentVersionLocation = getExtensionRelativeFile("../../vscode-client/out/converterBundle.version", false);
     const newVersionLocation = getExtensionRelativeFile("../../vscode-client/out/converterBundle.version.new", false);
 

--- a/robocorp-code/vscode-client/src/extension.ts
+++ b/robocorp-code/vscode-client/src/extension.ts
@@ -143,7 +143,7 @@ import { Mutex } from "./mutex";
 import { mergeEnviron } from "./subprocess";
 import { feedback } from "./rcc";
 import { showSubmitIssueUI } from "./submitIssue";
-import { ensureConvertBundle, ensureRobocorpCommons } from "./conversion";
+import { ensureConvertBundle } from "./conversion";
 import { TextDecoder } from "util";
 
 interface InterpreterInfo {
@@ -345,7 +345,6 @@ async function convertProject() {
     const DEFAULT_ERROR_STATUS = "Error while converting project.";
 
     const convertBundlePromise = ensureConvertBundle();
-    const robocorpCommonsPromise = ensureRobocorpCommons();
     try {
         // let the user decide where the conversion result will be saved
         const wsFolders: ReadonlyArray<WorkspaceFolder> = workspace.workspaceFolders;
@@ -384,12 +383,7 @@ async function convertProject() {
         if (!converterLocation) {
             throw new Error("There was an issue downloading the converter bundle. Please try again.");
         }
-        const converterBundle = require(converterLocation);
-
-        const convertYamlLocation = await robocorpCommonsPromise;
-        if (!convertYamlLocation) {
-            console.warn("Cannot find convert.yaml for commons");
-        }
+        const converterBundle = require(converterLocation.pathToExecutable);
 
         // let the user decide what type of project will be converted
         const vendorMap = {
@@ -412,7 +406,7 @@ async function convertProject() {
         const bytes = await workspace.fs.readFile(uri);
         const contents = new TextDecoder("utf-8").decode(bytes);
         const options = {
-            objectImplFile: convertYamlLocation,
+            objectImplFile: converterLocation.pathToConvertYaml,
         };
         const vendor = vendorMap[selectedFormat];
         const conversionResult: ConversionResult = await converterBundle.convert(vendor, contents, options);

--- a/robocorp-code/vscode-client/src/extension.ts
+++ b/robocorp-code/vscode-client/src/extension.ts
@@ -400,7 +400,11 @@ async function convertProject() {
         // actual conversion
         const bytes = await workspace.fs.readFile(uri);
         const contents = new TextDecoder("utf-8").decode(bytes);
-        const conversionResult: ConversionResult = await converterBundle.convert(vendorMap[selectedFormat], contents);
+        const home = roboConfig.getHome();
+        const options = {
+            // objectImplFile: workspace.fs.path(home, 'converter/blueprism/robocorp-commons/convert.yaml')
+        };
+        const conversionResult: ConversionResult = await converterBundle.convert(vendorMap[selectedFormat], contents, options);
         if (!converterBundle.isSuccessful(conversionResult)) {
             logError(
                 "Error converting file to Robocorp Robot",

--- a/robocorp-code/vscode-client/src/extension.ts
+++ b/robocorp-code/vscode-client/src/extension.ts
@@ -345,7 +345,7 @@ async function convertProject() {
     const DEFAULT_ERROR_STATUS = "Error while converting project.";
 
     const convertBundlePromise = ensureConvertBundle();
-    const robocorpCommonsPromise = ensureRobocorpCommons()
+    const robocorpCommonsPromise = ensureRobocorpCommons();
     try {
         // let the user decide where the conversion result will be saved
         const wsFolders: ReadonlyArray<WorkspaceFolder> = workspace.workspaceFolders;
@@ -388,7 +388,7 @@ async function convertProject() {
 
         const convertYamlLocation = await robocorpCommonsPromise;
         if (!convertYamlLocation) {
-            console.warn('Cannot find convert.yaml for commons');
+            console.warn("Cannot find convert.yaml for commons");
         }
 
         // let the user decide what type of project will be converted
@@ -412,7 +412,7 @@ async function convertProject() {
         const bytes = await workspace.fs.readFile(uri);
         const contents = new TextDecoder("utf-8").decode(bytes);
         const options = {
-            objectImplFile: convertYamlLocation
+            objectImplFile: convertYamlLocation,
         };
         const vendor = vendorMap[selectedFormat];
         const conversionResult: ConversionResult = await converterBundle.convert(vendor, contents, options);

--- a/robocorp-code/vscode-client/src/rcc.ts
+++ b/robocorp-code/vscode-client/src/rcc.ts
@@ -215,6 +215,7 @@ export async function download(
             let response: XHRResponse = await xhr({
                 "url": url,
                 "onProgress": onProgress,
+                timeout: 5000, /* 5 sec */
             });
             if (response.status == 200) {
                 // Ok, we've been able to get it.

--- a/robocorp-code/vscode-client/src/rcc.ts
+++ b/robocorp-code/vscode-client/src/rcc.ts
@@ -215,7 +215,7 @@ export async function download(
             let response: XHRResponse = await xhr({
                 "url": url,
                 "onProgress": onProgress,
-                timeout: 5000, /* 5 sec */
+                timeout: 5000 /* 5 sec */,
             });
             if (response.status == 200) {
                 // Ok, we've been able to get it.

--- a/robocorp-code/vscode-client/src/rcc.ts
+++ b/robocorp-code/vscode-client/src/rcc.ts
@@ -215,7 +215,6 @@ export async function download(
             let response: XHRResponse = await xhr({
                 "url": url,
                 "onProgress": onProgress,
-                timeout: 5000 /* 5 sec */,
             });
             if (response.status == 200) {
                 // Ok, we've been able to get it.

--- a/robocorp-code/yarn.lock
+++ b/robocorp-code/yarn.lock
@@ -7,20 +7,58 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/adm-zip@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@types/adm-zip/-/adm-zip-0.5.0.tgz#94c90a837ce02e256c7c665a6a1eb295906333c1"
+  integrity sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/glob@*":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.0.0.tgz#321607e9cbaec54f687a0792b2d1d370739455d2"
+  integrity sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
+
 "@types/mocha@^2.2.32":
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
   integrity sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==
+
+"@types/node@*":
+  version "18.7.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
+  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
 
 "@types/node@^13.0.00":
   version "13.13.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
   integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/vscode@1.65.0":
   version "1.65.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.65.0.tgz#042dd8d93c32ac62cb826cd0fa12376069d1f448"
   integrity sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==
+
+adm-zip@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
* Download converter js AND commons in a single zip file
* Call converter js with (optional) common implementation (convert.yaml)
