### PR TITLE
Add default output dir in the config snippet

### DIFF
--- a/robotframework-ls/codegen/codegen_package.py
+++ b/robotframework-ls/codegen/codegen_package.py
@@ -262,7 +262,10 @@ def get_json_contents():
                                 "target": '^"\\${file}"',
                                 "terminal": "integrated",
                                 "env": {},
-                                "args": [],
+                                "args": [
+                                    "--outputdir",
+                                    "output"
+                                ],
                             },
                         },
                         {
@@ -272,6 +275,10 @@ def get_json_contents():
                                 "type": "robotframework-lsp",
                                 "name": "Robot Framework: Launch template",
                                 "request": "launch",
+                                "args": [
+                                    "--outputdir",
+                                    "output"
+                                ],
                             },
                         },
                     ],


### PR DESCRIPTION
Adding the output folder in the launch configuration snippets, to make sure output files are always generated in the same folder, despite how you start the robot.