### PR TITLE
Bumping Inspector version

### DIFF
--- a/robocorp-code/bin/create_env/conda.yaml
+++ b/robocorp-code/bin/create_env/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
     - python=3.9.13 # https://pyreadiness.org/3.9/
     - pip=22.1.2 # https://pip.pypa.io/en/stable/news/
     - pip:
-          - robocorp-inspector==0.8.4 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
+          - robocorp-inspector==0.8.5 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
           - robotframework==4.1 # https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.1.rst

--- a/robocorp-code/bin/create_env/conda_vscode_darwin_amd64.yaml
+++ b/robocorp-code/bin/create_env/conda_vscode_darwin_amd64.yaml
@@ -8,5 +8,5 @@ dependencies:
     - pip=22.1.2 # https://pip.pypa.io/en/stable/news/
     - python.app=1.3 # https://anaconda.org/conda-forge/python.app/files
     - pip:
-          - robocorp-inspector==0.8.4 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
+          - robocorp-inspector==0.8.5 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
           - robotframework==4.1 # https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.1.rst

--- a/robocorp-code/bin/create_env/conda_vscode_linux_amd64.yaml
+++ b/robocorp-code/bin/create_env/conda_vscode_linux_amd64.yaml
@@ -9,5 +9,5 @@ dependencies:
     - pyside2=5.15.4 # https://wiki.qt.io/Qt_for_Python
     - qtpy=2.3.0 # https://github.com/spyder-ide/qtpy/blob/master/CHANGELOG.md
     - pip:
-          - robocorp-inspector==0.8.4 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
+          - robocorp-inspector==0.8.5 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
           - robotframework==4.1 # https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.1.rst

--- a/robocorp-code/bin/create_env/conda_vscode_windows_amd64.yaml
+++ b/robocorp-code/bin/create_env/conda_vscode_windows_amd64.yaml
@@ -8,5 +8,5 @@ dependencies:
     - pip=22.1.2 # https://pip.pypa.io/en/stable/news/
     - pywin32=303 # https://github.com/mhammond/pywin32/blob/main/CHANGES.txt
     - pip:
-          - robocorp-inspector==0.8.4 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
+          - robocorp-inspector==0.8.5 # https://github.com/robocorp/inspector/blob/master/CHANGELOG.md
           - robotframework==4.1 # https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.1.rst

--- a/robocorp-code/vscode-client/src/rcc.ts
+++ b/robocorp-code/vscode-client/src/rcc.ts
@@ -137,16 +137,16 @@ function getBaseAsZipBasename() {
     if (process.platform == "win32") {
         if (process.arch === "x64" || process.env.hasOwnProperty("PROCESSOR_ARCHITEW6432")) {
             // Check if node is a 64 bit process or if it's a 32 bit process running in a 64 bit processor.
-            basename = "e503f1697f52e0c8_windows_amd64.zip";
+            basename = "d7fd4affe11af01e_windows_amd64.zip";
         } else {
             throw new Error("Currently only Windows amd64 is supported.");
         }
     } else if (process.platform == "darwin") {
-        basename = "cbd90483bad12c79_darwin_amd64.zip";
+        basename = "d9e3a032fead8474_darwin_amd64.zip";
     } else {
         // Linux
         if (process.arch === "x64") {
-            basename = "f6203c4c6abbadb5_linux_amd64.zip";
+            basename = "e0367a488d82824f_linux_amd64.zip";
         } else {
             throw new Error("Currently only Linux amd64 is supported.");
         }


### PR DESCRIPTION
## v0.8.5 (date: 21.12.2022)
- New versions of `inspector-commons`
- Fixing several bugs & other issues with styling & functionality for all apps
- Updated dependencies to latest & stable versions
- Web Recorder - Improvements in performance & other bug fixes
- Web Recorder - Auto-scroll for the keyword list
- Web Recorder - Code Editor no longer readonly - but still indifferent to user changes as it will always update
- Web Picker - fixed buttons not displaying if no matches available
- All apps - a much more solid approach when it comes to closing the browser windows & the app window