### PR TITLE
Create new converter command: schema

### DIFF
--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -294,6 +294,15 @@ export async function convertAndSaveResults(
                     outputRelativePath: join(nextBasename, "api"),
                 });
 
+                rpaConversionCommands.push({
+                    command: CommandType.Schema,
+                    vendor: Format.AAV11,
+                    projects: projects,
+                    onProgress: undefined,
+                    tempFolder: tempDir,
+                    outputRelativePath: join(nextBasename, "schema"),
+                });
+
                 for (const it of opts.input) {
                     rpaConversionCommands.push({
                         vendor: Format.AAV11,
@@ -319,6 +328,7 @@ export async function convertAndSaveResults(
                     "Generate": "Generate API",
                     "Convert": "Convert",
                     "Analyse": "Analyse",
+                    "Schema": "Generate Schema",
                 };
                 // If we got here, things worked, let's write it to the filesystem.
                 const outputDirsWrittenTo = new Set<string>();

--- a/robocorp-code/vscode-client/src/protocols.ts
+++ b/robocorp-code/vscode-client/src/protocols.ts
@@ -173,6 +173,7 @@ export enum CommandType {
     Analyse = "Analyse",
     Convert = "Convert",
     Generate = "Generate",
+    Schema = "Schema",
 }
 
 export interface A360ConvertCommand {
@@ -230,9 +231,21 @@ export interface AAV11AnalyseCommand {
     outputRelativePath: string; // Used internally in Robocorp Code
 }
 
+export interface AAV11SchemaCommand {
+    command: CommandType.Schema;
+    vendor: Format.AAV11;
+    /* path to aapkg files */
+    projects: Array<string>;
+    /** properties that should be considered as ENUM  */
+    types?: Array<string>;
+    tempFolder: string;
+    onProgress: Progress;
+    outputRelativePath: string; // Used internally in Robocorp Code
+}
+
 export type BlueprismCommand = BlueprismConvertCommand;
 export type UiPathCommand = UiPathConvertCommand;
 export type A360Command = A360ConvertCommand;
-export type AAV11Command = AAV11ConvertCommand | AAV11GenerateCommand | AAV11AnalyseCommand;
+export type AAV11Command = AAV11ConvertCommand | AAV11GenerateCommand | AAV11AnalyseCommand | AAV11SchemaCommand;
 
 export type RPAConversionCommand = BlueprismCommand | UiPathCommand | A360Command | AAV11Command;


### PR DESCRIPTION
Schema and analysis are two different things. Schema is a representation of the grammar of a RPA language that is used to improve the converter while analysis is a report intended for end users.

Schema is also slower in general. Having it isolated allows us to run it optionally.