### PR TITLE
More robust conversion handling

### DIFF
--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -431,7 +431,11 @@ export async function convertAndSaveResults(
                     const conversionResult: ConversionResult = await conversionMain(converterBundle, command);
                     if (!isSuccessful(conversionResult)) {
                         const message = (<ConversionFailure>conversionResult).error;
-                        logError(`Error processing ${command.command} command`, new Error(message), "EXT_CONVERT_PROJECT");
+                        logError(
+                            `Error processing ${command.command} command`,
+                            new Error(message),
+                            "EXT_CONVERT_PROJECT"
+                        );
                         feedback(Metrics.CONVERTER_ERROR, command.vendor);
 
                         // skip and process next command

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -414,6 +414,7 @@ export async function convertAndSaveResults(
 
                 const results: ConversionResult[] = [];
                 const steps: number = rpaConversionCommands.length;
+                const errors: Array<[RPAConversionCommand, string]> = [];
                 let incrementStep: number = 0;
                 let currStep: number = 0;
 
@@ -429,6 +430,7 @@ export async function convertAndSaveResults(
                     await new Promise((r) => setTimeout(r, 5));
 
                     const conversionResult: ConversionResult = await conversionMain(converterBundle, command);
+
                     if (!isSuccessful(conversionResult)) {
                         const message = (<ConversionFailure>conversionResult).error;
                         logError(
@@ -437,6 +439,7 @@ export async function convertAndSaveResults(
                             "EXT_CONVERT_PROJECT"
                         );
                         feedback(Metrics.CONVERTER_ERROR, command.vendor);
+                        errors.push([command, message]);
 
                         // skip and process next command
                         continue;
@@ -510,6 +513,14 @@ ${outputDirsWrittenToStr.join("\n")}
 Created Files
 ----------------------------------
 ${filesWritten.join("\n")}
+
+Errors
+----------------------------------
+${
+    errors.length > 0
+        ? errors.map(([cmd, error]) => `Cannot process command ${cmd.command}, reason ${error}`).join("\n")
+        : "No errors"
+}
 `
                 );
 


### PR DESCRIPTION
**Problem.** 
* At the moment if one command fails, then the full conversion fails. This is not ideal because it could happen for a single bot while the others are just fine. 
* For similar reasons, we want to generate schemas per robots and not per a collection of robots. 

What we are doing in this PR
- [x] continue processing even if one command fails
- [x] show proper logs for failed robots
- [x] don't remove output folder, only temp

More maybe in next PRs
* split button: convert + schema because schema generation is slow