### PR TITLE
Passignore_git_dir flag to Robotidy

### DIFF
--- a/robocorp-python-ls-core/src/robocorp_ls_core/robotidy_wrapper.py
+++ b/robocorp-python-ls-core/src/robocorp_ls_core/robotidy_wrapper.py
@@ -28,5 +28,5 @@ def robot_tidy_source_format(ast, dirname: str) -> Optional[str]:
     _import_robotidy()
     from robotidy.api import transform_model
 
-    transformed_model = transform_model(ast, dirname)
+    transformed_model = transform_model(ast, dirname, ignore_git_dir=True)
     return transformed_model


### PR DESCRIPTION
Add ignore_git_dir option to keep searching for configuration file even if there is .git directory.

Relates #910

It will work on all Robotidy versions (thanks to ** kwargs in our implementation). It's not ideal implementation - it's better to supply flag value from the LSP configuration (default False) but I don't know where I can configuration options to LSP. It shouldn't affect users even with flag always set to True - if they don't have configuration file stored somewhere in parent directories.