### PR TITLE
A360 read adapters from folder

### DIFF
--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -161,7 +161,6 @@ export async function convertAndSaveResults(
         inputType: RPATypes;
         input: string[];
         outputFolder: string;
-        apiFolder: string;
         adapterFolderPath: string;
     }
 ): Promise<{
@@ -290,11 +289,6 @@ export async function convertAndSaveResults(
                         vendor: Format.BLUEPRISM,
                         command: CommandType.Convert,
                         releaseFileContent: contents,
-                        // This isn't added right now because it requires more work (both in explaining to the user as well
-                        // as the implementation).
-                        // We should collect all the keywords from files in a folder and then merge it with what's available
-                        // at converterLocation.pathToConvertYaml and create a new yaml to pass on to the converter.
-                        // apiImplementationFolderPath: opts.apiFolder,
                         apiImplementationFolderPath: converterLocation.pathToConvertYaml,
                         onProgress: undefined,
                         outputRelativePath: join(nextBasename, basename(it)),

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -14,7 +14,6 @@ interface ConversionInfoLastOptions {
     input: string[];
     generationResults: string;
     outputFolder: string;
-    apiFolder: string;
 }
 
 interface ConversionInfo {
@@ -22,7 +21,6 @@ interface ConversionInfo {
     input: string[];
     generationResults: string;
     outputFolder: string;
-    apiFolder: string;
     typeToLastOptions: Map<RPATypes, ConversionInfoLastOptions>;
 }
 
@@ -57,7 +55,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
     const wsFolders: ReadonlyArray<vscode.WorkspaceFolder> = vscode.workspace.workspaceFolders;
     let ws: vscode.WorkspaceFolder;
     let outputFolder = "";
-    let apiFolder = "";
     if (wsFolders !== undefined && wsFolders.length >= 1) {
         ws = wsFolders[0];
         outputFolder = ws.uri.fsPath;
@@ -72,7 +69,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
             "input": [], // files for BP, folders for others.
             "generationResults": "",
             "outputFolder": outputFolder,
-            "apiFolder": apiFolder,
         };
     }
 
@@ -86,7 +82,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
         "input": [],
         "generationResults": "",
         "outputFolder": outputFolder,
-        "apiFolder": apiFolder,
         "typeToLastOptions": typeToLastOptions,
     };
 
@@ -96,18 +91,9 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
 
         // Validate that what we had saved is valid for new versions.
         // i.e.: Backward-compatibility.
-        if (conversionInfo.apiFolder === undefined) {
-            conversionInfo.apiFolder = "";
-        }
 
         if (conversionInfo.typeToLastOptions[RPATypes.aav11] === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.aav11] = generateDefaultOptions();
-        }
-
-        for (const [key, val] of Object.entries(conversionInfo.typeToLastOptions)) {
-            if (val.apiFolder === undefined) {
-                val.apiFolder = "";
-            }
         }
     }
 
@@ -128,15 +114,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
                         panel.webview.postMessage({ command: "setOutputFolder", "outputFolder": outputFolder });
                     }
                     return;
-                case "onClickApiFolder":
-                    let apiFolder: string = "";
-                    try {
-                        const currentApiFolder = message.currentApiFolder;
-                        apiFolder = await onClickApiFolder(currentApiFolder);
-                    } finally {
-                        panel.webview.postMessage({ command: "setApiFolder", "apiFolder": apiFolder });
-                    }
-                    return;
                 case "onClickAdd":
                     let input: string[] = [];
                     try {
@@ -155,7 +132,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
                         const outputFolder = contents["outputFolder"];
                         const inputType = contents["inputType"];
                         const input = contents["input"];
-                        const apiFolder = contents["apiFolder"];
                         // adapter files are at the machine level and location cannot be changed by converter webview
                         const home = await getRobocorpHome();
                         const adapterFolderPath = join(home, "rca", inputType, "adapters");
@@ -164,7 +140,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
                             outputFolder,
                             inputType,
                             input,
-                            apiFolder,
                             adapterFolderPath,
                         });
                     } finally {
@@ -185,21 +160,6 @@ async function onClickOutputFolder(currentOutputFolder: any): Promise<string> {
         "canSelectFiles": false,
         "canSelectMany": false,
         "openLabel": `Select output folder`,
-        "defaultUri": defaultUri,
-    });
-    if (uris && uris.length > 0) {
-        return uris[0].fsPath;
-    }
-    return "";
-}
-
-async function onClickApiFolder(currentApiFolder: any): Promise<string> {
-    const defaultUri = vscode.Uri.file(currentApiFolder);
-    let uris: vscode.Uri[] = await vscode.window.showOpenDialog({
-        "canSelectFolders": true,
-        "canSelectFiles": false,
-        "canSelectMany": false,
-        "openLabel": `Select API folder`,
         "defaultUri": defaultUri,
     });
     if (uris && uris.length > 0) {
@@ -265,7 +225,6 @@ async function onClickConvert(
         inputType: RPATypes;
         input: string[];
         outputFolder: string;
-        apiFolder: string;
         adapterFolderPath: string;
     }
 ): Promise<{

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -64,8 +64,6 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
     } else {
         throw new Error("Conversion Accelerator can work only in a workspace");
     }
-    // check if exists ws/rca/a360/adapters
-    // read files from there
 
     const typeToLastOptions = new Map<RPATypes, ConversionInfoLastOptions>();
 

--- a/robocorp-code/vscode-client/src/protocols.ts
+++ b/robocorp-code/vscode-client/src/protocols.ts
@@ -180,6 +180,7 @@ export interface A360ConvertCommand {
     command: CommandType.Convert;
     vendor: Format.A360;
     projectFolderPath: string;
+    adapterFilePaths: Array<string>;
     onProgress: Progress;
     outputRelativePath: string; // Used internally in Robocorp Code
 }

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -48,10 +48,6 @@
                 margin-top: 50px;
             }
 
-            #apiFolderDiv {
-                margin-top: 50px;
-            }
-
             #outputFolderDiv {
                 margin-top: 20px;
             }
@@ -100,31 +96,26 @@
             "input": ["c:/temp/file.uipath", "c:/temp/file2.uipath"],
             "generationResults": "",
             "outputFolder": "",
-            "apiFolder": "",
             "typeToLastOptions": {
                 "uipath": {
                     "input": [],
                     "generationResults": "",
                     "outputFolder": "",
-                    "apiFolder": ""
                 },
                 "blueprism": {
                     "input": [],
                     "generationResults": "",
                     "outputFolder": "",
-                    "apiFolder": ""
                 },
                 "a360": {
                     "input": [],
                     "generationResults": "",
                     "outputFolder": "",
-                    "apiFolder": ""
                 }
                 "aav11": {
                     "input": [],
                     "generationResults": "",
                     "outputFolder": "",
-                    "apiFolder": ""
                 }
             }
         }
@@ -240,22 +231,10 @@
             updateUIConversionResultFromData();
             updateUIFilesFromData();
             updateUIOutputFolderFromData();
-            updateUIApiFolderFromData();
 
             // The UI has just been updated, so, it's Ok to update one UI setting
             // from another UI setting...
             updateUILabelFilesOrFoldersFromUI();
-        }
-
-        function updateUIApiFolderFromData() {
-            const show = globalConversionInfo.inputType === "blueprism";
-            // document.getElementById("apiFolderDiv").style.display = show ? "block" : "none";
-
-            // Note: always disabled for now (may be re-enabled later).
-            document.getElementById("apiFolderDiv").style.display = "none";
-
-            const apiFolderText = document.getElementById("apiFolderText");
-            apiFolderText.value = globalConversionInfo.apiFolder;
         }
 
         function updateUILabelFilesOrFoldersFromUI() {
@@ -377,35 +356,11 @@
             persistState();
         }
 
-        function onClickApiFolder() {
-            if (vscode) {
-                // Disable button while sending.
-                const apiFolderBt = document.getElementById("apiFolderBt");
-                apiFolderBt.disabled = true;
-                vscode.postMessage({
-                    command: "onClickApiFolder",
-                    currentApiFolder: globalConversionInfo.apiFolder,
-                });
-            } else {
-                console.log("On click api folder");
-                handleApiFolderCommand({ "apiFolder": "" });
-            }
-        }
-
-        function onApiFolderTextChanged() {
-            const apiFolderText = document.getElementById("apiFolderText");
-            const text = apiFolderText.value;
-            globalConversionInfo.apiFolder = text;
-            persistState();
-        }
-
         function onClickConvert() {
             if (vscode) {
                 // Disable button while sending.
                 const outputFolderBt = document.getElementById("outputFolderBt");
                 outputFolderBt.disabled = true;
-                const apiFolderBt = document.getElementById("apiFolderBt");
-                apiFolderBt.disabled = true;
                 const conversionResultsDiv = document.getElementById("conversionResults");
                 conversionResultsDiv.textContent = "Please wait, making analysis/conversion...";
                 vscode.postMessage({
@@ -414,7 +369,6 @@
                         outputFolder: globalConversionInfo.outputFolder,
                         inputType: globalConversionInfo.inputType,
                         input: globalConversionInfo.input,
-                        apiFolder: globalConversionInfo.apiFolder,
                     },
                 });
             } else {
@@ -442,8 +396,6 @@
             } finally {
                 const outputFolderBt = document.getElementById("outputFolderBt");
                 outputFolderBt.disabled = false;
-                const apiFolderBt = document.getElementById("apiFolderBt");
-                apiFolderBt.disabled = false;
             }
         }
 
@@ -458,20 +410,6 @@
             } finally {
                 const outputFolderBt = document.getElementById("outputFolderBt");
                 outputFolderBt.disabled = false;
-            }
-        }
-
-        function handleApiFolderCommand(message) {
-            try {
-                if (message.apiFolder) {
-                    clearResultsAndUpdateUI();
-                    globalConversionInfo.apiFolder = message.apiFolder;
-                    updateUIApiFolderFromData();
-                    persistState();
-                }
-            } finally {
-                const apiFolderBt = document.getElementById("apiFolderBt");
-                apiFolderBt.disabled = false;
             }
         }
 
@@ -519,9 +457,6 @@
                     break;
                 case "setOutputFolder":
                     handleOutputFolderCommand(message);
-                    break;
-                case "setApiFolder":
-                    handleApiFolderCommand(message);
                     break;
                 case "conversionFinished":
                     handleConversionFinishedCommand(message.result);
@@ -605,32 +540,6 @@
                 <div id="analysisResults">Analysis results:</div>
             </div>
             <br /> -->
-
-            <!-- Note: actually never displayed right now as it needs more work... -->
-            <div id="apiFolderDiv" class="divEntry" style="display: none">
-                <label
-                    >API folder (by default, when doing the conversion, dummy stubs are generated for Robot Keywords
-                    used in the bot, but it's possible for the conversion to reuse Keywords already implemented by
-                    pointing to a folder that contains such APIs):</label
-                >
-                <div style="display: flex">
-                    <input
-                        value=""
-                        style="flex-grow: 1"
-                        type="text"
-                        id="apiFolderText"
-                        oninput="onApiFolderTextChanged()"
-                        placeholder="Leave empty to create initial commons API."
-                    />
-                    <input
-                        value="..."
-                        style="margin-left: 5px; padding-left: 20px; padding-right: 20px"
-                        type="submit"
-                        id="apiFolderBt"
-                        onclick="onClickApiFolder()"
-                    />
-                </div>
-            </div>
 
             <div id="conversionDiv" class="divEntry">
                 <input value="Convert to Robot" type="submit" id="convertBt" onclick="onClickConvert()" />


### PR DESCRIPTION
Let's revamp the API idea, with a different name.

Adapters are RF keywords that "adapt" Gen 1 RPA activities to RF keywords. Here, we implement the basic structure for A360.

Since we want to keep UI as simple as possible, the idea is that adapter code is not handled by users. Instead, adapters are stored in `$ROBOCORP_HOME/rca/VENDOR/adapters` folder. The folder files are "merged" and keywords are used as adapters if they occur in a to-be-converted bot.

I removed the old code of API (aka `apiFolder`) just to keep the code cleaner.