### PR TITLE
CA: create folders recursively

### DIFF
--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -475,6 +475,10 @@ export async function convertAndSaveResults(
                     encoding: BufferEncoding = "utf-8"
                 ): Promise<void> {
                     filesWritten.push(file);
+                    const { dir } = path.parse(file);
+                    if (dir) {
+                        await makeDirs(dir);
+                    }
                     await writeToFile(file, content, { encoding });
                 }
 


### PR DESCRIPTION
CA returns file paths with folders. We need to create them otherwise files cannot be written.