### PR TITLE
CONV - enable python as a target language

### DIFF
--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -161,6 +161,7 @@ export async function convertAndSaveResults(
         inputType: RPATypes;
         input: string[];
         outputFolder: string;
+        targetLanguage: string;
         adapterFolderPath: string;
     }
 ): Promise<{
@@ -201,6 +202,7 @@ export async function convertAndSaveResults(
 
     try {
         let nextBasename: string;
+        const targetLanguage = opts.targetLanguage;
         switch (opts.inputType) {
             case RPATypes.uipath: {
                 nextBasename = await findNextBasenameIn(opts.outputFolder, "converted-uipath");
@@ -237,6 +239,7 @@ export async function convertAndSaveResults(
                         vendor: Format.UIPATH,
                         command: CommandType.Convert,
                         projectFolderPath: it,
+                        targetLanguage,
                         onProgress: undefined,
                         outputRelativePath: join(nextBasename, basename(it)),
                     });
@@ -290,6 +293,7 @@ export async function convertAndSaveResults(
                         command: CommandType.Convert,
                         releaseFileContent: contents,
                         apiImplementationFolderPath: converterLocation.pathToConvertYaml,
+                        targetLanguage,
                         onProgress: undefined,
                         outputRelativePath: join(nextBasename, basename(it)),
                     });
@@ -347,6 +351,7 @@ export async function convertAndSaveResults(
                         command: CommandType.Convert,
                         projectFolderPath: it,
                         adapterFilePaths,
+                        targetLanguage,
                         onProgress: undefined,
                         outputRelativePath: join(nextBasename, basename(it)),
                     });
@@ -400,6 +405,7 @@ export async function convertAndSaveResults(
                         command: CommandType.Convert,
                         projects: [it],
                         onProgress: undefined,
+                        targetLanguage,
                         tempFolder: tempDir,
                         outputRelativePath: join(nextBasename, "conversion", basename(it)),
                     });

--- a/robocorp-code/vscode-client/src/conversion.ts
+++ b/robocorp-code/vscode-client/src/conversion.ts
@@ -39,6 +39,13 @@ export enum RPATypes {
     aav11 = "aav11",
 }
 
+export enum TargetLanguages {
+    RF = "RF",
+    PYTHON = "PYTHON",
+}
+
+export const DEFAULT_TARGET_LANGUAGE = TargetLanguages.RF;
+
 export const RPA_TYPE_TO_CAPTION = {
     "uipath": "UiPath",
     "blueprism": "Blue Prism",

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -14,6 +14,7 @@ interface ConversionInfoLastOptions {
     input: string[];
     generationResults: string;
     outputFolder: string;
+    targetLanguage: string;
 }
 
 interface ConversionInfo {
@@ -70,6 +71,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
             "input": [], // files for BP, folders for others.
             "generationResults": "",
             "outputFolder": outputFolder,
+            "targetLanguage": "RF",
         };
     }
 
@@ -84,7 +86,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
         "generationResults": "",
         "outputFolder": outputFolder,
         "typeToLastOptions": typeToLastOptions,
-        "targetLanguage": "python",
+        "targetLanguage": "RF",
     };
 
     const oldState = context.globalState.get("robocorpConversionViewState");

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -6,7 +6,14 @@ import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import * as vscode from "vscode";
 import { logError } from "./channel";
-import { ensureConvertBundle, convertAndSaveResults, RPATypes, RPA_TYPE_TO_CAPTION } from "./conversion";
+import {
+    ensureConvertBundle,
+    convertAndSaveResults,
+    RPATypes,
+    RPA_TYPE_TO_CAPTION,
+    TargetLanguages,
+    DEFAULT_TARGET_LANGUAGE,
+} from "./conversion";
 import { getExtensionRelativeFile } from "./files";
 import { getRobocorpHome } from "./rcc";
 
@@ -14,7 +21,7 @@ interface ConversionInfoLastOptions {
     input: string[];
     generationResults: string;
     outputFolder: string;
-    targetLanguage: string;
+    targetLanguage: TargetLanguages;
 }
 
 interface ConversionInfo {
@@ -22,8 +29,8 @@ interface ConversionInfo {
     input: string[];
     generationResults: string;
     outputFolder: string;
-    targetLanguage: string;
     typeToLastOptions: Map<RPATypes, ConversionInfoLastOptions>;
+    targetLanguage: TargetLanguages;
 }
 
 let panel: vscode.WebviewPanel | undefined = undefined;
@@ -71,7 +78,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
             "input": [], // files for BP, folders for others.
             "generationResults": "",
             "outputFolder": outputFolder,
-            "targetLanguage": "RF",
+            "targetLanguage": DEFAULT_TARGET_LANGUAGE,
         };
     }
 
@@ -86,7 +93,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
         "generationResults": "",
         "outputFolder": outputFolder,
         "typeToLastOptions": typeToLastOptions,
-        "targetLanguage": "RF",
+        "targetLanguage": DEFAULT_TARGET_LANGUAGE,
     };
 
     const oldState = context.globalState.get("robocorpConversionViewState");
@@ -98,6 +105,20 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
 
         if (conversionInfo.typeToLastOptions[RPATypes.aav11] === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.aav11] = generateDefaultOptions();
+        }
+
+        // if previous old state, target language might not be defined
+        if (!conversionInfo.typeToLastOptions[RPATypes.a360].targetLanguage) {
+            conversionInfo.typeToLastOptions[RPATypes.a360].targetLanguage = DEFAULT_TARGET_LANGUAGE;
+        }
+        if (!conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage) {
+            conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage = DEFAULT_TARGET_LANGUAGE;
+        }
+        if (!conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage) {
+            conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage = DEFAULT_TARGET_LANGUAGE;
+        }
+        if (!conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage) {
+            conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
     }
 

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -21,6 +21,7 @@ interface ConversionInfo {
     input: string[];
     generationResults: string;
     outputFolder: string;
+    targetLanguage: string;
     typeToLastOptions: Map<RPATypes, ConversionInfoLastOptions>;
 }
 
@@ -83,6 +84,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
         "generationResults": "",
         "outputFolder": outputFolder,
         "typeToLastOptions": typeToLastOptions,
+        "targetLanguage": "python",
     };
 
     const oldState = context.globalState.get("robocorpConversionViewState");
@@ -130,6 +132,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
                     try {
                         const contents = message.contents;
                         const outputFolder = contents["outputFolder"];
+                        const targetLanguage = contents["targetLanguage"];
                         const inputType = contents["inputType"];
                         const input = contents["input"];
                         // adapter files are at the machine level and location cannot be changed by converter webview
@@ -138,6 +141,7 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
 
                         result = await onClickConvert(convertBundlePromise, {
                             outputFolder,
+                            targetLanguage,
                             inputType,
                             input,
                             adapterFolderPath,
@@ -225,6 +229,7 @@ async function onClickConvert(
         inputType: RPATypes;
         input: string[];
         outputFolder: string;
+        targetLanguage: string;
         adapterFolderPath: string;
     }
 ): Promise<{

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -114,10 +114,10 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
         if (conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
-        if (conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage  === undefined) {
+        if (conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
-        if (conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage  === undefined) {
+        if (conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
     }

--- a/robocorp-code/vscode-client/src/conversionView.ts
+++ b/robocorp-code/vscode-client/src/conversionView.ts
@@ -108,16 +108,16 @@ export async function showConvertUI(context: vscode.ExtensionContext) {
         }
 
         // if previous old state, target language might not be defined
-        if (!conversionInfo.typeToLastOptions[RPATypes.a360].targetLanguage) {
+        if (conversionInfo.typeToLastOptions[RPATypes.a360].targetLanguage === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.a360].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
-        if (!conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage) {
+        if (conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.blueprism].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
-        if (!conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage) {
+        if (conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage  === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.uipath].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
-        if (!conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage) {
+        if (conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage  === undefined) {
             conversionInfo.typeToLastOptions[RPATypes.aav11].targetLanguage = DEFAULT_TARGET_LANGUAGE;
         }
     }

--- a/robocorp-code/vscode-client/src/protocols.ts
+++ b/robocorp-code/vscode-client/src/protocols.ts
@@ -171,6 +171,7 @@ export interface A360ConvertCommand {
     command: CommandType.Convert;
     vendor: Format.A360;
     projectFolderPath: string;
+    targetLanguage: string;
     adapterFilePaths: Array<string>;
     onProgress: Progress;
     outputRelativePath: string; // Used internally in Robocorp Code
@@ -199,6 +200,7 @@ export interface UiPathConvertCommand {
     command: CommandType.Convert;
     vendor: Format.UIPATH;
     projectFolderPath: string;
+    targetLanguage: string;
     onProgress: Progress;
     outputRelativePath: string; // Used internally in Robocorp Code
 }
@@ -226,6 +228,7 @@ export interface BlueprismConvertCommand {
     command: CommandType.Convert;
     vendor: Format.BLUEPRISM;
     releaseFileContent: string;
+    targetLanguage: string;
     apiImplementationFolderPath?: string;
     onProgress: Progress;
     outputRelativePath: string; // Used internally in Robocorp Code
@@ -246,6 +249,7 @@ export interface AAV11ConvertCommand {
     /* path to aapkg files */
     projects: Array<string>;
     tempFolder: string;
+    targetLanguage: string;
     onProgress: Progress;
     outputRelativePath: string; // Used internally in Robocorp Code
 }

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -559,7 +559,7 @@
                 <br />
                 <select id="targetLanguage" onchange="onTargetLanguageChanged()">
                     <option value="PYTHON">Python</option>
-                    <option value="RF">Robotframework</option>
+                    <option value="RF">Robot Framework</option>
                 </select>
             </div>
 

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -96,7 +96,7 @@
             "input": ["c:/temp/file.uipath", "c:/temp/file2.uipath"],
             "generationResults": "",
             "outputFolder": "",
-            "targetLanguage": "PYTHON",
+            "targetLanguage": "RF",
             "typeToLastOptions": {
                 "uipath": {
                     "input": [],

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -171,6 +171,7 @@
                 "input": globalConversionInfo.input,
                 "generationResults": globalConversionInfo.generationResults,
                 "outputFolder": globalConversionInfo.outputFolder,
+                "targetLanguage": globalConversionInfo.targetLanguage
             };
             globalConversionInfo.typeToLastOptions[globalConversionInfo.inputType] = currOptions;
         }
@@ -179,6 +180,7 @@
             const lastOptions = globalConversionInfo.typeToLastOptions[globalConversionInfo.inputType];
             globalConversionInfo.input = lastOptions.input;
             globalConversionInfo.generationResults = lastOptions.generationResults;
+            globalConversionInfo.targetLanguage = lastOptions.targetLanguage;
             if (lastOptions.outputFolder) {
                 // Keep the same output folder (just set it if it was already saved for the other type).
                 globalConversionInfo.outputFolder = lastOptions.outputFolder;
@@ -532,7 +534,7 @@
                 <label>Target language:</label>
                 <br />
                 <select id="targetLanguage" onchange="onTargetLanguageChanged()">
-                    <option value="PYTHON" selected="selected">Python</option>
+                    <option value="PYTHON">Python</option>
                     <option value="RF">Robotframework</option>
                 </select>
             </div>

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -96,6 +96,7 @@
             "input": ["c:/temp/file.uipath", "c:/temp/file2.uipath"],
             "generationResults": "",
             "outputFolder": "",
+            "targetLanguage": "PYTHON",
             "typeToLastOptions": {
                 "uipath": {
                     "input": [],
@@ -221,6 +222,11 @@
             }
         }
 
+        function updateUITargetLanguageFromData() {
+            const targetLanguageSelect = document.getElementById("targetLanguage");
+            targetLanguageSelect.value = globalConversionInfo.targetLanguage;
+        }
+
         function updateUIOutputFolderFromData() {
             const outputFolderText = document.getElementById("outputFolderText");
             outputFolderText.value = globalConversionInfo.outputFolder;
@@ -231,6 +237,7 @@
             updateUIConversionResultFromData();
             updateUIFilesFromData();
             updateUIOutputFolderFromData();
+            updateUITargetLanguageFromData();
 
             // The UI has just been updated, so, it's Ok to update one UI setting
             // from another UI setting...
@@ -356,6 +363,14 @@
             persistState();
         }
 
+         function onTargetLanguageChanged() {
+            const targetLanguageSelect = document.getElementById("targetLanguage");
+            const selectedTargetLanguage = targetLanguageSelect.value;
+            globalConversionInfo.targetLanguage = selectedTargetLanguage;
+            persistState();
+        }
+
+
         function onClickConvert() {
             if (vscode) {
                 // Disable button while sending.
@@ -367,6 +382,7 @@
                     command: "onClickConvert",
                     contents: {
                         outputFolder: globalConversionInfo.outputFolder,
+                        targetLanguage: globalConversionInfo.targetLanguage,
                         inputType: globalConversionInfo.inputType,
                         input: globalConversionInfo.input,
                     },
@@ -510,6 +526,15 @@
                     <input value="Select" type="submit" id="addBt" onclick="onClickAdd()" />
                 </div>
                 <div id="inputFilesOrFolders"></div>
+            </div>
+
+            <div id="targetLanguageDiv" class="divEntry">
+                <label>Target language:</label>
+                <br />
+                <select id="targetLanguage" onchange="onTargetLanguageChanged()">
+                    <option value="PYTHON" selected="selected">Python</option>
+                    <option value="RF">Robotframework</option>
+                </select>
             </div>
 
             <div id="outputFolderDiv" class="divEntry">

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -593,7 +593,7 @@
             <br /> -->
 
             <div id="conversionDiv" class="divEntry">
-                <input value="Convert to Robot" type="submit" id="convertBt" onclick="onClickConvert()" />
+                <input value="Convert" type="submit" id="convertBt" onclick="onClickConvert()" />
                 <pre id="conversionResults">Conversion results:</pre>
             </div>
         </div>

--- a/robocorp-code/vscode-client/templates/converter.html
+++ b/robocorp-code/vscode-client/templates/converter.html
@@ -229,6 +229,16 @@
             targetLanguageSelect.value = globalConversionInfo.targetLanguage;
         }
 
+        function hideUITargetLanguage() {
+            const targetLanguageSelect = document.getElementById("targetLanguageDiv");
+            targetLanguageDiv.style.display = 'none';
+        }
+
+        function showUITargetLanguage() {
+            const targetLanguageDiv = document.getElementById("targetLanguageDiv");
+            targetLanguageDiv.style.display = 'inline-grid';
+        }
+
         function updateUIOutputFolderFromData() {
             const outputFolderText = document.getElementById("outputFolderText");
             outputFolderText.value = globalConversionInfo.outputFolder;
@@ -244,6 +254,12 @@
             // The UI has just been updated, so, it's Ok to update one UI setting
             // from another UI setting...
             updateUILabelFilesOrFoldersFromUI();
+
+            if (isTargetSelectionDisabled()) {
+                hideUITargetLanguage();
+            } else {
+                showUITargetLanguage();
+            }
         }
 
         function updateUILabelFilesOrFoldersFromUI() {
@@ -273,6 +289,14 @@
                 return false;
             }
             return true;
+        }
+
+        function isTargetSelectionDisabled() {
+            const curr = getCurrentUIType();
+            if (curr === "blueprism") {
+                return true;
+            }
+            return false;
         }
 
         function getCurrentUIType() {


### PR DESCRIPTION
We add a dropdown in order to allow the selection of Python as a target language.

1. For now RF is set as default. This will change soon, but for now we want to release this feature silently.
2. We don't show the dropdown for BP because the Python backend is In progress
