### PR TITLE
Fix bug in extension startup to respect environment pythonpath

### DIFF
--- a/robotframework-ls/vscode-client/src/extension.ts
+++ b/robotframework-ls/vscode-client/src/extension.ts
@@ -332,7 +332,7 @@ const serverOptions: ServerOptions = async function () {
 
         let src: string = path.resolve(__dirname, "../../src");
         const serverProcess = cp.spawn(executableAndMessage.executable[0], args, {
-            env: { ...process.env, PYTHONPATH: src },
+            env: { ...process.env, PYTHONPATH: src + (!process.env.PYTHONPATH ? '' : ':' + process.env.PYTHONPATH) },
         });
         if (!serverProcess || !serverProcess.pid) {
             throw new Error(


### PR DESCRIPTION
In the current version the extension wipes the PYTHONPATH environment variable and overrides it with its own. It should rather append itself to allow the path to allow system specific import locations to work. This is a problem especially if using nix as the robotframework extension is installed in another path than where the python binary is installed.