### PR TITLE
always archive the test results

### DIFF
--- a/.github/workflows/tests-robotframework-lsp.yml
+++ b/.github/workflows/tests-robotframework-lsp.yml
@@ -109,6 +109,7 @@ jobs:
         RUN_TESTS_TIMEOUT: 800
       run: python -u ../../robocorp-python-ls-core/tests/run_tests.py -rfE -otests_output -vv .
     - uses: actions/upload-artifact@v1
+      if: always()
       with:
         name: tests_output.${{ matrix.name }}.txt
         path: robotframework-ls/tests/tests_output


### PR DESCRIPTION
How about archiving test results - always? Because right now if there are any failures - those are not uploaded and can be seen only in a browser/workflow step section