### PR TITLE
Fix uri issue

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,7 +26,6 @@ jobs:
           
           cd robocorp-code
           
-          poetry config virtualenvs.prefer-active-python true
           poetry install
           poetry run python -m pip install robotframework-output-stream
           

--- a/.github/workflows/pre-release-robotframework-lsp.yml
+++ b/.github/workflows/pre-release-robotframework-lsp.yml
@@ -52,8 +52,8 @@ jobs:
         python -m dev vendor-robocorp-ls-core
         python -m dev vendor-robotframework-interactive
         python -m dev vendor-robotframework-output-stream
-    - name: Fix README references
-      run: python -m dev fix-readme
+    # - name: Fix README references
+    #   run: python -m dev fix-readme
     - name: Build wheel
       working-directory: ./robotframework-ls/src
       run: |
@@ -78,7 +78,7 @@ jobs:
     #     path: robotframework-intellij/build/distributions/
 
     # Note: always publish a pre-release to VSCode marketplace.
-    - name: Publish pre-release to vscode marketplace
-      run: vsce publish -p $VSCE_TOKEN --pre-release
-      env:
-        VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+    # - name: Publish pre-release to vscode marketplace
+    #   run: vsce publish -p $VSCE_TOKEN --pre-release
+    #   env:
+    #     VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/robotframework-ls/vscode-client/src/testview.ts
+++ b/robotframework-ls/vscode-client/src/testview.ts
@@ -103,6 +103,9 @@ export function computeUriTestId(uri: string): string {
     if (uri.startsWith("id:")) {
         throw new Error("It seems that this uri is actually a test id already.");
     }
+    if (process.platform == "win32") {
+        uri = uri.toLowerCase();
+    }
     return "id:" + uri;
 }
 
@@ -158,6 +161,10 @@ function removeTreeStructure(uri: vscode.Uri) {
 function addTreeStructure(workspaceFolder: vscode.WorkspaceFolder, uri: vscode.Uri): vscode.TestItem {
     let workspaceFolderPath = workspaceFolder.uri.path;
     let uriPath = uri.path;
+    if (process.platform == "win32") {
+        workspaceFolderPath = workspaceFolderPath.toLowerCase();
+        uriPath = uriPath.toLowerCase();
+    }
     const path = posixPath.relative(workspaceFolderPath, uriPath);
     const parts = path.split("/");
 


### PR DESCRIPTION
- Revert change from c0ce4c07d32f6ce08f8e309919f97cfb407ece64 that broke the "Run Suite" code lens and the testing sidebar in VS Code
- Remove unsupported poetry config setting
- Comment out readme fix and prerelease to VS Code marketplace in pre-release-robotframework-lsp.yml